### PR TITLE
Skip word if Japanese translation is unavailable

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -44,6 +44,10 @@ for (const word of words) {
     continue;
   }
 
+  if (!(word.en && word.ja)) {
+    continue;
+  }
+
   enToJaTranslations.push({
     en: word.en,
     ja: word.ja,
@@ -72,6 +76,10 @@ let jaToEnTranslations = [];
 
 for (const word of words) {
   if (word._meta?.translator === false || word._meta?.translator?.jaToEn === false) {
+    continue;
+  }
+
+  if (!(word.en && word.ja)) {
     continue;
   }
 


### PR DESCRIPTION
In f7cefd0, we added a word without Japanese translation.
This works for the Dictionary, but not for the Translate. It failed to generate proper dictionary data due to missing Japanese translation.

This PR fixes the bug by skipping the word without Japanese translation.