### PR TITLE
Keep both Abdju Road and Abdju Pit

### DIFF
--- a/dataset/dictionary/locations.json5
+++ b/dataset/dictionary/locations.json5
@@ -1312,6 +1312,14 @@
     zhCN: "舍身步道",
     pronunciationJa: "しゃしんのみち",
     tags: [ "sumeru", "location" ],
+    notes: "世界任務「黄金の眠り」の途中で、捨身の坑に変化する。",
+  },
+  {
+    en: "Abdju Pit",
+    ja: "捨身の坑",
+    pronunciationJa: "しゃしんのみち",
+    tags: [ "sumeru", "location" ],
+    notes: "世界任務「黄金の眠り」の途中で、捨身の道から変化する。",
   },
   {
     en: "Dar al-Shifa",

--- a/dataset/dictionary/locations.json5
+++ b/dataset/dictionary/locations.json5
@@ -1307,9 +1307,9 @@
     tags: [ "sumeru", "location" ],
   },
   {
-    en: "Abdju Pit",
-    ja: "捨身の坑",
-    zhCN: "舍身步道", // TODO Check if it is renamed
+    en: "Abdju Road",
+    ja: "捨身の道",
+    zhCN: "舍身步道",
     pronunciationJa: "しゃしんのみち",
     tags: [ "sumeru", "location" ],
   },

--- a/dataset/redirect/words.json
+++ b/dataset/redirect/words.json
@@ -1,5 +1,4 @@
 {
-  "abdju-road": "abdju-pit",
   "capitano": "il-capitano",
   "captain-of-the-knights-of-favonius-reconnaissance-company": "captain-of-the-reconnaissance-company",
   "clan": "gunnhildr-clan",


### PR DESCRIPTION
I thought Abdju Road was renamed to Abdju Pit permanently, but in fact, it was renamed by processing a world quest Golden Slumber.
Therefore, I keep both Abdju Road and Abdju Pit in the Dictionary.

ref: #65