### PR TITLE
Add script to list missing Chinese translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "status": "node scripts/status.js",
+    "todo": "node scripts/todo.js",
     "test": "npm run build && NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "find ./dataset/ -name *.json5 | xargs json5 --validate && eslint --ext .js,.mjs,.cjs,.ts,.json,.json5 --ignore-path .gitignore .",
     "release": "node scripts/release.js"

--- a/scripts/todo.js
+++ b/scripts/todo.js
@@ -1,0 +1,27 @@
+import { readdir, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import JSON5 from "json5";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const dicDir = resolve(__dirname, "../dataset/dictionary");
+const json5FileNames = await readdir(dicDir);
+
+console.info("# Words without Chinese translation");
+
+for (const json5FileName of json5FileNames) {
+  const json5Path = resolve(dicDir, json5FileName);
+  const json5Dic = await readFile(json5Path, { encoding: "utf-8" });
+
+  const wordsWithoutChinese = JSON5.parse(json5Dic)
+    .filter(word => !word.zhCN);
+
+  if (0 < wordsWithoutChinese.length) {
+    console.info(""); // line break
+    console.info(`  ## ${json5FileName}`);
+  }
+
+  for (const word of wordsWithoutChinese) {
+    console.info(`    - ${word.en} (${word.ja})`);
+  }
+}


### PR DESCRIPTION
Run `npm run todo` in your terminal and it shows the words without Chinese translations.

```shell
$ npm run todo

> todo
> node scripts/todo.js

# Words without Chinese translation

  ## artifacts.json5
    - Deepwood Memories (深林の記憶)

  ## characters.json5
    - Lupical (ルピカ)
    - Antoha (アントハー)
    - Kaveh (カーヴェ)
…
```