### PR TITLE
Avoid running `husky install` when it is not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run build && NODE_OPTIONS=--experimental-vm-modules jest",
     "lint": "find ./dataset/ -name *.json5 | xargs json5 --validate && eslint --ext .js,.mjs,.cjs,.ts,.json,.json5 --ignore-path .gitignore .",
     "release": "node scripts/release.js",
-    "prepare": "husky install"
+    "prepare": "if npm list husky > /dev/null; then husky install; fi"
   },
   "dependencies": {
     "dotenv": "^16.0.0",


### PR DESCRIPTION
This if a follow-up PR for #97.