### PR TITLE
Add dependabot.yml

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "xicri"
+    open-pull-requests-limit: 0 # only receive security updates
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "xicri"
+    open-pull-requests-limit: 0 # only receive security updates
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "xicri"
+    open-pull-requests-limit: 0 # only receive security updates


### PR DESCRIPTION
Replace Snyk with Dependabot because Snyk raises a false-positive error that package-lock.json is not synced with package.json.