### PR TITLE
Skip deployment to Cloudflare Pages on CI triggered by contributors

### DIFF
--- a/scripts/release-pages.sh
+++ b/scripts/release-pages.sh
@@ -8,6 +8,11 @@ if [[ -f "${DIRNAME}/../.env" ]]; then
   . "${DIRNAME}/../.env"
 fi
 
+if [[ "${CI}" == "true" && -z "${CLOUDFLARE_API_TOKEN-}" ]]; then
+  echo "Skipping deployment to Cloudflare Pages because credentials are not available for contributors"
+  exit 0
+fi
+
 if [[ "${NODE_ENV}" == "production" ]]; then
   npx wrangler pages publish ./dist --project-name=genshin-langdata
 else


### PR DESCRIPTION
Currently, GitHub Actions fails on the PRs from the contributors. GitHub Actions try to deploy to Cloudflare Pages, but Cloudflare credentials are not available for contributors and it can't deploy.

With this PR, deployment process to Cloudflare Pages will be skipped if the workflow is triggered by PRs from the contributors.