### PR TITLE
Reverse-sort words by update date ― fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "form-data": "^4.0.0",
         "iconv-lite": "^0.6.3",
         "jest": "^29.4.3",
+        "jest-expect-message": "^1.1.3",
         "json5": "^2.2.2",
         "klona": "^2.0.4",
         "lodash-es": "^4.17.21",
@@ -24,7 +25,6 @@
       },
       "devDependencies": {
         "husky": "^8.0.3",
-        "jest-expect-message": "^1.1.3",
         "lint-staged": "^13.1.2"
       },
       "engines": {
@@ -5213,8 +5213,7 @@
     "node_modules/jest-expect-message": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.3.tgz",
-      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg==",
-      "dev": true
+      "integrity": "sha512-bTK77T4P+zto+XepAX3low8XVQxDgaEqh3jSTQOG8qvPpD69LsIdyJTa+RmnJh3HNSzJng62/44RPPc7OIlFxg=="
     },
     "node_modules/jest-get-type": {
       "version": "29.4.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "form-data": "^4.0.0",
     "iconv-lite": "^0.6.3",
     "jest": "^29.4.3",
+    "jest-expect-message": "^1.1.3",
     "json5": "^2.2.2",
     "klona": "^2.0.4",
     "lodash-es": "^4.17.21",
@@ -36,7 +37,6 @@
   },
   "devDependencies": {
     "husky": "^8.0.3",
-    "jest-expect-message": "^1.1.3",
     "lint-staged": "^13.1.2"
   }
 }


### PR DESCRIPTION
This PR is the follow-up for #117.
This PR moves `jest-expect-message` from `devDependencies` to `dependencies` so that it can be loaded on test in the release process run under `NODE_ENV=production`.