### PR TITLE
Suppress unnecessary `console` output

### DIFF
--- a/tests/dictionary.test.js
+++ b/tests/dictionary.test.js
@@ -7,6 +7,16 @@ import { Dictionary } from "../libs/dictionary.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
+const consoleInfoOriginal = global.console.info;
+
+beforeAll(() => {
+  global.console.info = () => {};
+});
+
+afterAll(() => {
+  global.console.info = consoleInfoOriginal;
+});
+
 test("addUpdateAt() adds updatedAt properly", async () => {
   const wordsLocal = [
     {

--- a/tests/json5.test.js
+++ b/tests/json5.test.js
@@ -212,7 +212,6 @@ test("if property values of dictionary JSON complies the format.", async () => {
 
 test("if words are reverse-sorted by `updatedAt`", () => {
   words.reduce((wordA, wordB) => {
-    console.log(wordA, wordB);
     expect(
       DateTime.fromISO(wordA.updatedAt) >= DateTime.fromISO(wordB.updatedAt),
       `wordA: ${ JSON.stringify(wordA, null, 2) }` + "\n" + `wordB: ${ JSON.stringify(wordB, null, 2) }`


### PR DESCRIPTION
This PR stops unnecessary output by `console.log()` / `console.info()`.