### PR TITLE
(Re:) Add/Modify new keywords for Ver.4.6

### DIFF
--- a/dataset/dictionary/characters.json5
+++ b/dataset/dictionary/characters.json5
@@ -784,6 +784,14 @@
     notes: "v4.1 期間限定イベント「流れゆく水に詩を紡いで」に登場する純水精霊",
     notesZh: "v4.1 活动「游水酝诗籍」的纯水精灵",
   },
+  {
+    en: "Sir Pouncelot",
+    ja: "橙色騎士",
+    zhCN: "大桔骑士",
+    pronunciationJa: "おれんじきし",
+    tags: [ "mondstadt", "character-sub" ],
+    notes: "v4.5 期間限定イベント「モフモフの城にゃん冒険」に登場する猫",
+  },
 
   //
   // Liyue - Main Characters
@@ -2683,6 +2691,12 @@
     zhCN: "布耶尔",
     tags: [ "sumeru", "title" ],
   },
+  {
+    en: "Sethos",
+    ja: "セトス",
+    zhCN: "赛索斯",
+    tags: [ "sumeru", "character-main" ],
+  },
 
   //
   // Sumeru - NPCs
@@ -4364,6 +4378,51 @@
     zhCN: "纳齐森科鲁兹",
     tags: [ "fontaine", "character-sub" ],
   },
+  {
+    en: "Peruere",
+    ja: "ペルヴェーレ",
+    zhCN: "佩露薇利",
+    tags: [ "fontaine", "character-sub" ],
+    notes: "「アルレッキーノ」の本名",
+  },
+  {
+    en: "Crucabena",
+    ja: "クルセビナ",
+    zhCN: "库嘉维娜",
+    tags: [ "snezhnaya", "fontaine", "character-sub" ],
+    notes: "先代の「召使」",
+  },
+  {
+    en: "Clervie",
+    ja: "クリーヴ",
+    zhCN: "克雷薇",
+    tags: [ "fontaine", "character-sub" ],
+  },
+  {
+    en: "Osse",
+    ja: "ウッスー",
+    zhCN: "小呜斯",
+    tags: [ "fontaine", "character-sub" ],
+    notes: "「ウラノポリスのウラニデス」の略称",
+  },
+  {
+    en: "Boethius",
+    ja: "ボエティウス",
+    zhCN: "波爱修斯",
+    tags: [ "fontaine", "character-sub" ],
+  },
+  {
+    en: "Scylla",
+    ja: "スキュラ",
+    zhCN: "斯库拉",
+    tags: [ "fontaine", "character-sub" ],
+  },
+  {
+    en: "Cassiodo",
+    ja: "カッシオドル",
+    zhCN: "卡西奥多",
+    tags: [ "fontaine", "character-sub" ],
+  },
 
   //
   // Natlan
@@ -4607,7 +4666,7 @@
     zhCN: "阿蕾奇诺",
     notes: "[召使](/the-knave/)の通称",
     notesZh: "[仆人](/the-knave/)的通称",
-    tags: [ "snezhnaya", "character-sub" ],
+    tags: [ "snezhnaya", "fontaine", "character-main" ],
   },
   {
     en: "The Knave",
@@ -4616,7 +4675,7 @@
     pronunciationJa: "めしつかい",
     notes: "[アルレッキーノ](/arlecchino/)のコードネーム",
     notesZh: "[阿蕾奇诺](/arlecchino/)的代号",
-    tags: [ "snezhnaya", "character-sub", "title" ],
+    tags: [ "snezhnaya", "fontaine", "character-main", "title" ],
   },
   {
     en: "Sandrone",

--- a/dataset/dictionary/characters.json5
+++ b/dataset/dictionary/characters.json5
@@ -784,14 +784,6 @@
     notes: "v4.1 期間限定イベント「流れゆく水に詩を紡いで」に登場する純水精霊",
     notesZh: "v4.1 活动「游水酝诗籍」的纯水精灵",
   },
-  {
-    en: "Sir Pouncelot",
-    ja: "橙色騎士",
-    zhCN: "大桔骑士",
-    pronunciationJa: "おれんじきし",
-    tags: [ "mondstadt", "character-sub" ],
-    notes: "v4.5 期間限定イベント「モフモフの城にゃん冒険」に登場する猫",
-  },
 
   //
   // Liyue - Main Characters

--- a/dataset/dictionary/characters.json5
+++ b/dataset/dictionary/characters.json5
@@ -4382,8 +4382,8 @@
     en: "Peruere",
     ja: "ペルヴェーレ",
     zhCN: "佩露薇利",
-    tags: [ "fontaine", "character-sub" ],
-    notes: "「アルレッキーノ」の本名",
+    tags: [ "snezhnaya", "fontaine", "character-main", "enemy-boss" ],
+    notes: "アルレッキーノの本名",
   },
   {
     en: "Crucabena",
@@ -4666,7 +4666,7 @@
     zhCN: "阿蕾奇诺",
     notes: "[召使](/the-knave/)の通称",
     notesZh: "[仆人](/the-knave/)的通称",
-    tags: [ "snezhnaya", "fontaine", "character-main" ],
+    tags: [ "snezhnaya", "fontaine", "character-main", "enemy-boss" ],
   },
   {
     en: "The Knave",
@@ -4675,7 +4675,7 @@
     pronunciationJa: "めしつかい",
     notes: "[アルレッキーノ](/arlecchino/)のコードネーム",
     notesZh: "[阿蕾奇诺](/arlecchino/)的代号",
-    tags: [ "snezhnaya", "fontaine", "character-main", "title" ],
+    tags: [ "snezhnaya", "fontaine", "character-main", "enemy-boss", "title" ],
   },
   {
     en: "Sandrone",

--- a/dataset/dictionary/drops-boss.json5
+++ b/dataset/dictionary/drops-boss.json5
@@ -431,4 +431,31 @@
     tags: [ "liyue", "drop-boss" ],
     notes: "山隠れの猊獣のドロップアイテム",
   },
+  {
+    en: "Fragment of a Golden Melody",
+    ja: "金色の旋律の断章",
+    zhCN: "金色旋律的断章",
+    tags: [ "fontaine", "drop-boss" ],
+  },
+  {
+    en: "Silken Feather",
+    ja: "絹織りの羽",
+    zhCN: "丝织之羽",
+    pronunciationJa: "きぬおりのはね",
+    tags: [ "fontaine", "drop-boss" ],
+  },
+  {
+    en: "Denial and Judgment",
+    ja: "否定と裁決",
+    zhCN: "否定裁断",
+    pronunciationJa: "ひていとさいけつ",
+    tags: [ "fontaine", "drop-boss" ],
+  },
+  {
+    en: "Fading Candle",
+    ja: "残火の灯燭",
+    zhCN: "残火灯烛",
+    pronunciationJa: "ざんかのとうそく",
+    tags: [ "fontaine", "drop-boss" ],
+  },
 ]

--- a/dataset/dictionary/drops.json5
+++ b/dataset/dictionary/drops.json5
@@ -732,4 +732,46 @@
     pronunciationJa: "せいすいぎょく",
     tags: [ "liyue", "drop" ],
   },
+  {
+    en: "Chasmlight Fin",
+    ja: "淵光の羽鰭",
+    zhCN: "渊光鳍翅",
+    pronunciationJa: "えんこうのうき", // TODO Need Check
+    tags: [ "liyue", "drop" ],
+  },
+  {
+    en: "Lunar Fin",
+    ja: "月光の羽鰭",
+    zhCN: "月色鳍翅",
+    pronunciationJa: "げっこうのうき", // TODO Need Check
+    tags: [ "liyue", "drop" ],
+  },
+  {
+    en: "Feathery Fin",
+    ja: "翼状の羽鰭",
+    zhCN: "羽状鳍翅",
+    pronunciationJa: "よくじょうのうき", // TODO Need Check
+    tags: [ "liyue", "drop" ],
+  },
+  {
+    en: "Still-Smoldering Hilt",
+    ja: "光揺らぐ剣の柄",
+    zhCN: "未熄的剑柄",
+    pronunciationJa: "ひかりゆらぐけんのつか",
+    tags: [ "fontaine", "drop" ],
+  },
+  {
+    en: "Splintered Hilt",
+    ja: "折れた剣の柄",
+    zhCN: "裂断的剑柄",
+    pronunciationJa: "おれたけんのつか",
+    tags: [ "fontaine", "drop" ],
+  },
+  {
+    en: "Ruined Hilt",
+    ja: "砕けた剣の柄",
+    zhCN: "残毁的剑柄",
+    pronunciationJa: "くだけたけんのつか",
+    tags: [ "fontaine", "drop" ],
+  },
 ]

--- a/dataset/dictionary/enemies.json5
+++ b/dataset/dictionary/enemies.json5
@@ -2213,4 +2213,26 @@
     pronunciationJa: "やまがくれのげいじゅう",
     tags: [ "liyue", "enemy-boss" ],
   },
+  {
+    en: "Statue of Marble and Brass",
+    ja: "白石と黄銅の彫像",
+    zhCN: "白石与黄铜的造像",
+    pronunciationJa: "はくせきとおうどうのちょうぞう",
+    tags: [ "fontaine", "enemy-boss" ],
+    notes: "「魔像レガトゥス」の通称",
+  },
+  {
+    en: "Legatus Golem",
+    ja: "魔像レガトゥス",
+    zhCN: "魔像督军",
+    pronunciationJa: "まぞうレガトゥス",
+    tags: [ "fontaine", "enemy-boss" ],
+  },
+  {
+    en: "Praetorian Golem",
+    ja: "魔像プラエトリアニ",
+    zhCN: "魔像禁卫",
+    pronunciationJa: "まぞうプラエトリアニ",
+    tags: [ "fontaine", "enemy" ],
+  },
 ]

--- a/dataset/dictionary/foods.json5
+++ b/dataset/dictionary/foods.json5
@@ -1111,6 +1111,25 @@
     zhCN: "仙跳墙",
     tags: [ "food" ],
   },
+  {
+    en: "Haggis",
+    ja: "ハギス",
+    zhCN: "羊杂哈吉斯",
+    tags: [ "food" ],
+  },
+  {
+    en: "Bulle Souffle",
+    ja: "バブルスフレ",
+    zhCN: "泡泡舒芙蕾",
+    tags: [ "food" ],
+  },
+  {
+    en: "Mega-Meaty Sushi",
+    ja: "お肉たっぷり寿司",
+    zhCN: "肉满满寿司",
+    tags: [ "food" ],
+    notes: "スシローコラボ「回転の宴」",
+  },
 
   //
   // Specialties (オリジナル料理)
@@ -1412,6 +1431,14 @@
     notes: "申鶴のオリジナル料理",
   },
   // ▲▲ Unconfirmed ▲▲
+  {
+    en: "Encompassing Gladness",
+    ja: "四喜円満",
+    zhCN: "四喜圆满",
+    pronunciationJa: "しきえんまん", // TODO Need Check
+    tags: [ "food", "liyue" ],
+    notes: "閑雲のオリジナル料理",
+  },
 
   // Inazuma
   {

--- a/dataset/dictionary/locations.json5
+++ b/dataset/dictionary/locations.json5
@@ -2163,10 +2163,10 @@
 
   {
     en: "Petrichor",
-    ja: "ペトリコール",
+    ja: "ペトリコール町",
     zhCN: "佩特莉可",
+    pronunciationJa: "ペトリコールちょう",
     tags: [ "fontaine", "location" ],
-    notes: "恐らくフォンテーヌの地名。v2.8 期間限定イベント「からくり械画」でフェリックス・ユーグが言及。",
   },
   {
     en: "Morte Region",
@@ -2240,6 +2240,60 @@
     en: "Tower of Ipsissimus",
     ja: "イプシシマスの塔",
     zhCN: "自体自身之塔",
+    tags: [ "fontaine", "location" ],
+  },
+  {
+    en: "Nostoi Region",
+    ja: "ノストイ地区",
+    zhCN: "诺思托伊区",
+    pronunciationJa: "ノストイちく",
+    tags: [ "fontaine", "location" ],
+  },
+  {
+    en: "Faded Castle",
+    ja: "色褪せた城",
+    zhCN: "褪色古堡",
+    pronunciationJa: "いろあせたしろ",
+    tags: [ "fontaine", "location" ],
+  },
+  {
+    en: "Sea of Bygone Eras",
+    ja: "往日の海",
+    zhCN: "旧日之海",
+    pronunciationJa: "おうじつのうみ",
+    tags: [ "fontaine", "location" ],
+  },
+  {
+    en: "Initinum Iani",
+    ja: "ヤヌスの門",
+    zhCN: "雅努斯之门",
+    pronunciationJa: "ヤヌスのもん",
+    tags: [ "fontaine", "location" ],
+  },
+  {
+    en: "Hortus Euergetis",
+    ja: "ホルトゥス・ユーゲレティス",
+    zhCN: "优恩花园",
+    tags: [ "fontaine", "location" ],
+  },
+  {
+    en: "Alta Semita",
+    ja: "アルタ・セミタ",
+    zhCN: "崇高大道",
+    tags: [ "fontaine", "location" ],
+  },
+  {
+    en: "Clivus Capitolinus",
+    ja: "アピトリヌス山",
+    zhCN: "卡皮托林山",
+    pronunciationJa: "アピトリヌスさん",
+    tags: [ "fontaine", "location" ],
+  },
+  {
+    en: "Collegium Phonascorum",
+    ja: "諧律院",
+    zhCN: "谐律院",
+    pronunciationJa: "かいりついん",
     tags: [ "fontaine", "location" ],
   },
 

--- a/dataset/dictionary/weapons.json5
+++ b/dataset/dictionary/weapons.json5
@@ -1519,4 +1519,11 @@
     notes: "v4.5 期間限定イベント「巧みなる錬金経営」報酬",
     notesZh: "v4.5 活动「升炼研巧万策金」奖励",
   },
+  {
+    en: "Crimson Moon's Semblance",
+    ja: "赤月のシルエット",
+    zhCN: "赤月之形",
+    pronunciationJa: "あかつきのシルエット", // TODO Need Check
+    tags: [ "weapon", "polearm" ],
+  },
 ]

--- a/dataset/dictionary/y-events.json5
+++ b/dataset/dictionary/y-events.json5
@@ -212,6 +212,14 @@
     notes: "v4.5 期間限定イベント",
   },
   {
+    en: "Sir Pouncelot",
+    ja: "橙色騎士",
+    zhCN: "大桔骑士",
+    pronunciationJa: "おれんじきし",
+    tags: [ "event", "mondstadt", "character-sub" ],
+    notes: "v4.5 期間限定イベント「モフモフの城にゃん冒険」に登場する猫",
+  },
+  {
     en: "Rolling Crossfire",
     ja: "ポヨコロ・クロスファイア",
     zhCN: "圆圆滚滚交叉火力",


### PR DESCRIPTION
I accidentally closed #194 from @yasuking0304 and cannot reopen the PR, so I restored the commits included in #194 in this PR.
Closes #193.

Original Post in #193:

> ## Add/Modified new keywords for Ver.4.6
>
> I referred to here and picked up the missing basic keywords.
>
> - added version 4.5-4.6 characters
> - added version 4.6 drops-boss
> - added version 4.4-4.6 drops
> - added version 4.6 enemies
> - added version 4.6 items
> - added version 4.4-4.6 foods
> - added version 4.6 locations
> - added version 4.6 weapons
>
> ### issue #193