### PR TITLE
Move vitest to dependencies so that it can be installed on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,7 @@
     "node-fetch": "^3.2.4",
     "npm-run-all": "^4.1.5",
     "pinyin-tone": "^2.1.2",
+    "vitest": "^1.6.0",
     "wrangler": "^3.55.0"
-  },
-  "devDependencies": {
-    "vitest": "^1.6.0"
   }
 }


### PR DESCRIPTION
`devDependencies` are not installed on release processes.