### PR TITLE
Add new keywords for Version 4.3 - 4.7 genshin-langdata

### DIFF
--- a/dataset/dictionary/artifacts.json5
+++ b/dataset/dictionary/artifacts.json5
@@ -489,4 +489,33 @@
       zhCN: [ "乐团套" ],
     },
   },
+  {
+    en: "Song of Days Past",
+    ja: "在りし日の歌",
+    zhCN: "昔时之歌",
+    pronunciationJa: "ありしひのうた",
+    tags: [ "artifact" ],
+  },
+  {
+    en: "Nighttime Whispers in the Echoing Woods",
+    ja: "残暑の森で囁かれる夜話",
+    zhCN: "回声之林夜话",
+    pronunciationJa: "ざんしょのもりでささやかれるよばなし",
+    tags: [ "artifact" ],
+  },
+  {
+    en: "Fragment of Harmonic Whimsy",
+    ja: "諧律奇想の断章",
+    zhCN: "谐律异想断章",
+    pronunciationJa: "かいりつきそうのだんしょう",
+    notes: "諧律は中国語で調和・ハーモニーを意味する言葉。日本では戦前に使われていた旧語",
+    tags: [ "artifact" ],
+  },
+  {
+    en: "Unfinished Reverie",
+    ja: "遂げられなかった想い",
+    zhCN: "未竟的遐思",
+    pronunciationJa: "とげられなかったおもい",
+    tags: [ "artifact" ],
+  },
 ]

--- a/dataset/dictionary/domains.json5
+++ b/dataset/dictionary/domains.json5
@@ -519,4 +519,25 @@
     tags: [ "fontaine", "domain" ],
     notesZh: "吞星之鲸的掉落物",
   },
+  {
+    en: "Waterfall Wen",
+    ja: "滝を臨む廃都",
+    zhCN: "临瀑之城",
+    pronunciationJa: "たきをのぞむはいと",
+    tags: [ "fontaine", "domain" ],
+  },
+  {
+    en: "Faded Theater",
+    ja: "色褪せた劇場",
+    zhCN: "褪色的剧场",
+    pronunciationJa: "いろあせたげきじょう",
+    tags: [ "fontaine", "domain" ],
+  },
+  {
+    en: "Scattered Ruins",
+    ja: "ぼろぼろの廃墟",
+    zhCN: "零落丘墟",
+    pronunciationJa: "ぼろぼろのはいきょ",
+    tags: [ "fontaine", "domain" ],
+  },
 ]

--- a/dataset/dictionary/quests.json5
+++ b/dataset/dictionary/quests.json5
@@ -260,6 +260,15 @@
     notes: "魔神任務第四章第五幕",
   },
 
+  // Traveler
+  {
+    en: "Bedtime Story",
+    ja: "ベッドタイムストーリー",
+    zhCN: "睡前故事",
+    tags: [ "sumeru", "quest-archon" ],
+    notes: "魔神任務第四章第六幕",
+  },
+
   {
     en: "Interlude",
     ja: "間章",
@@ -2244,9 +2253,18 @@
     tags: [ "fontaine", "quest-story" ],
   },
   {
+    en: "Diluvies Chapter",
+    ja: "潮汐の章",
+    zhCN: "潮涌之章",
+    pronunciationJa: "ちょうせきのしょう",
+    notes: "ヌヴィレットの伝説任務",
+    tags: [ "fontaine", "quest-story" ],
+  },
+  {
     en: "Cerberus Chapter",
     ja: "獄守犬の章",
     zhCN: "守狱犬之章",
+    pronunciationJa: "ごくもりけんのしょう",
     notes: "リオセスリの伝説任務",
     tags: [ "fontaine", "quest-story" ],
   },
@@ -2255,7 +2273,60 @@
     ja: "頌歌者の章",
     zhCN: "司颂之章",
     pronunciationJa: "しょうかしゃのしょう",
+    notes: "フリーナの伝説任務",
     tags: [ "fontaine", "quest-story" ],
+  },
+  {
+    en: "Rosa Multiflora Chapter",
+    ja: "野薔薇の章",
+    zhCN: "野蔷薇之章",
+    pronunciationJa: "のばらのしょう",
+    notes: "ナヴィアの伝説任務",
+    tags: [ "fontaine", "quest-story" ],
+  },
+  {
+    en: "Grus Serena Chapter",
+    ja: "閑鶴の章",
+    zhCN: "闲鹤之章",
+    pronunciationJa: "かんかくのしょう",
+    notes: "閑雲の伝説任務",
+    tags: [ "liyue", "quest-story" ],
+  },
+  {
+    en: "Cisoria Chapter",
+    ja: "糸切鋏の章",
+    zhCN: "丝切铗之章",
+    pronunciationJa: "いときりばさみのしょう",
+    notes: "千織の伝説任務",
+    tags: [ "fontaine", "quest-story" ],
+  },
+  {
+    en: "Ignis Purgatorius Chapter",
+    ja: "浄煉の炎の章",
+    zhCN: "净炼火之章",
+    notes: "アルレッキーノの伝説任務",
+    tags: [ "fontaine", "quest-story" ],
+  },
+  {
+    en: "Rappiera Chapter",
+    ja: "レイピアの章",
+    zhCN: "迅捷剑之章",
+    notes: "クロリンデの伝説任務",
+    tags: [ "fontaine", "quest-story" ],
+  },
+  {
+    en: "Nereides Chapter",
+    ja: "ネレイスの章",
+    zhCN: "海精之章",
+    notes: "シグウィンの伝説任務",
+    tags: [ "fontaine", "quest-story" ],
+  },
+  {
+    en: "Ponum de Ambra Chapter",
+    ja: "ポムム・ドゥ・アンブラの章",
+    zhCN: "香氛瓶之章",
+    notes: "エミリエの伝説任務",
+    tags: [ "sumeru", "quest-story" ],
   },
 
   //

--- a/dataset/dictionary/sereniteapot.json5
+++ b/dataset/dictionary/sereniteapot.json5
@@ -264,6 +264,13 @@
     pronunciationJa: "トーチざい",
     tags: [ "sereniteapot", "fontaine" ],
   },
+  {
+    en: "Ash Wood",
+    ja: "ホワイトアッシュ材",
+    zhCN: "白梣木",
+    pronunciationJa: "ホワイトアッシュざい",
+    tags: [ "sereniteapot", "fontaine" ],
+  },
 
   //
   // Furnishing (調度品)

--- a/dataset/dictionary/y-events.json5
+++ b/dataset/dictionary/y-events.json5
@@ -439,6 +439,14 @@
 
   // v4.7
   {
+    en: "An Everlasting Dream Intertwined",
+    ja: "永き夢を紡いで",
+    zhCN: "纺坠终久之梦",
+    pronunciationJa: "ながきゆめをつむいで",
+    tags: [ "event" ],
+    notes: "v4.7 バージョンサブタイトル",
+  },
+  {
     en: "Mutual Security Enhancing Simulation",
     ja: "堅守演習",
     zhCN: "安固诸方之述演",
@@ -479,6 +487,14 @@
   },
 
   // v4.6
+  {
+    en: "Two Worlds Aflame, the Crimson Night Fades",
+    ja: "双界に至る炎、熄えゆく赤夜",
+    zhCN: "两界为火，赤夜将熄",
+    pronunciationJa: "そうかいにいたるほのおきえゆくせきや", // TODO Need Check
+    tags: [ "event" ],
+    notes: "v4.6 バージョンサブタイトル",
+  },
   {
     en: "Windtrace: Seekers and Strategy",
     ja: "風の行方・妙策の陣",


### PR DESCRIPTION
Closes #288
Adds Fontaine's Story Quest, Domain, Drops and Artifact, we will add keywords(Additional omissions).

Archon Quest
| English | Japanese | Chinese Simplifed | Note(ja)  | memo|
|---|---|---|---|---|
| Bedtime Story | ベッドタイムストーリー | 睡前故事

Sub Story Title(Event)
| English | Japanese | Chinese Simplifed | Note(ja)  | memo|
|---|---|---|---|---|
| An Everlasting Dream Intertwined | 永き夢を紡いで | 纺坠终久之梦 | v4.7 バージョンサブタイトル　| v4.7
| Two Worlds Aflame, the Crimson Night Fades | 双界に至る炎、熄えゆく赤夜 | 两界为火，赤夜将熄 | v4.6 バージョンサブタイトル | v4.6

Story Quest
| English | Japanese | Chinese Simplifed | Note(ja)  | memo|
|---|---|---|---|---|
| Diluvies Chapter | 潮汐の章 | 潮涌之章 | ヌヴィレットの伝説任務| add tags:[fontaine]
|入力済み| 獄守犬の章(ごくもりけんのしょう) | | リオセスリの伝説任務 
|入力済み| 頌歌者の章 | | フリーナの伝説任務
| Rosa Multiflora Chapter | 野薔薇の章 | 野蔷薇之章 | ナヴィアの伝説任務| add tags:[fontaine]
| Grus Serena Chapter | 閑鶴の章 | 闲鹤之章 | 閑雲の伝説任務| add tags:[liyue]
| Cisoria Chapter | 糸切鋏の章 | 丝切铗之章 | 千織の伝説任務| add tags:[fontaine]
| Ignis Purgatorius Chapter | 浄煉の炎の章 | 净炼火之章 | アルレッキーノの伝説任務| add tags:[fontaine]
| Rappiera Chapter | レイピアの章 | 迅捷剑之章 | クロリンデの伝説任務 | add tags:[fontaine]
| Nereides Chapter | ネレイスの章 | 海精之章 | シグウィンの伝説任務| add tags:[fontaine]
| Ponum de Ambra Chapter | ポムム・ドゥ・アンブラの章 | 香氛瓶之章 | エミリエの伝説任務 | add tags:[sumeru]

Domain of fontaine
| English | Japanese | Chinese Simplifed | Note(ja) | memo |
|---|---|---|---|---|
| Waterfall Wen | 滝を臨む廃都 | 临瀑之城 || | 
| Faded Theater | 色褪せた劇場 | 褪色的剧场 || | 
| Scattered Ruins | ぼろぼろの廃墟 | 零落丘墟 || |

Artifact in fontaine
| English | Japanese | Chinese Simplifed | Note(ja) | memo|
|---|---|---|---|---|
| Song of Days Past | 在りし日の歌 | 昔时之歌
| Nighttime Whispers in the Echoing Woods | 残暑の森で囁かれる夜話 | 回声之林夜话
| Fragment of Harmonic Whimsy | 諧律奇想の断章 | 谐律异想断章
| Unfinished Reverie | 遂げられなかった想い | 未竟的遐思

Serenitea Pot
| English | Japanese | Chinese Simplifed | Note(ja) | memo|
|---|---|---|---|---|
| Ash Wood | ホワイトアッシュ材 | 白梣木 |
