### PR TITLE
ci: trigger deployment for Cloudflare Pages, not genshin-dictionary's GitHub Actions

### DIFF
--- a/.github/workflows/deploy-dic.yml
+++ b/.github/workflows/deploy-dic.yml
@@ -11,13 +11,9 @@ jobs:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     env:
-      GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+      CFPAGES_DEPLOYMENT_WEBHOOK: ${{ secrets.CFPAGES_DEPLOYMENT_WEBHOOK }}
 
     steps:
       - name: Trigger genshin-dictionary deployment
         run: |
-          curl -sS -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${GH_PERSONAL_ACCESS_TOKEN}" \
-            https://api.github.com/repos/xicri/genshin-dictionary/dispatches \
-            -d '{ "event_type": "langdata-update" }'
+          curl -X POST "${CFPAGES_DEPLOYMENT_WEBHOOK}"


### PR DESCRIPTION
By the migration from Fly.io to Cloudflare Pages, genshin-dictionary deployment after genshin-langdata update accidentally stopped.
This PR fixes the CI so that genshin-dictionary is deployed after genshin-langdata is deployed.