### PR TITLE
Add new keywords for September, 2024 genshin-langdata

### DIFF
--- a/dataset/dictionary/characters.json5
+++ b/dataset/dictionary/characters.json5
@@ -2880,7 +2880,10 @@
     en: "Alrani",
     ja: "アラニ",
     zhCN: "爱拉尼",
-    tags: [ "sumeru", "inazuma", "character-sub" ],
+    notesEn: "Character appearing in many world quests, including \"And This Treasure Goes To...\", \"The Path of Papers\"",
+    notes: "「霊矩のお宝」「学を求む長き道」など、多くの世界任務に登場する人物",
+    notesZh: "出现在「灵矩有宝予何人」，「求学漫漫路」等众多世界任务中的角色",
+    tags: [ "sumeru", "liyue", "inazuma", "natlan", "character-sub" ],
   },
   {
     en: "Ahangar",
@@ -3691,6 +3694,15 @@
     zhCN: "奥乌兹",
     tags: [ "sumeru", "character-sub" ],
   },
+  {
+    en: "Narzam",
+    ja: "ナザム",
+    zhCN: "娜赞",
+    notesEn: "Character appearing in the world quest \"The Path of Papers\"",
+    notes: "世界任務「学を求む長き道」に登場する人物",
+    notesZh: "世界任务「求学漫漫路」中出现的角色",
+    tags: [ "sumeru", "natlan", "character-sub" ],
+  },
 
   //
   // Fontaine ― Playable Characters
@@ -3724,8 +3736,7 @@
     en: "Egeria",
     ja: "エゲリア",
     zhCN: "厄歌莉娅",
-    tags: [ "fontaine", "character-main" ],
-    notes: "タグのプレイアブル・NPC 分類は仮",
+    tags: [ "fontaine", "character-sub" ],
   },
   {
     en: "Navia",
@@ -5030,6 +5041,25 @@
     zhCN: "特拉佐莉",
     notes: "部族見聞「祝福を祈り、テペトルに告ぐ」第二幕に登場する人物",
     tags: [ "natlan", "character-sub" ],
+  },
+  {
+    en: "Ifa",
+    ja: "イファ",
+    zhCN: "伊法",
+    notesEn: "Saurian vet from the \"Flower-Feather Clan\"",
+    notes: "「花翼の集」の竜医。タグのプレイアブル・NPC 分類は仮", // TODO ムアラニ/カチーナ/キィニチのボイスでのみ出てくる人物
+    notesZh: "「花羽会」中的龙医",
+    tags: [ "natlan", "character-sub" ],
+  },
+  {
+    en: "Pyro Archon",
+    ja: "炎神",
+    zhCN: "火神",
+    tags: [ "natlan", "title" ],
+    pronunciationJa: "えんじん",
+    variants: {
+      en: [ "Pyro God", "God of Pyro" ],
+    },
   },
 
   //

--- a/dataset/dictionary/characters.json5
+++ b/dataset/dictionary/characters.json5
@@ -5047,7 +5047,7 @@
     ja: "イファ",
     zhCN: "伊法",
     notesEn: "Saurian vet from the \"Flower-Feather Clan\"",
-    notes: "「花翼の集」の竜医。タグのプレイアブル・NPC 分類は仮", // TODO ムアラニ/カチーナ/キィニチのボイスでのみ出てくる人物
+    notes: "「花翼の集」の竜医。タグのプレイアブル・NPC 分類は仮", // TODO A person who is mentioned in Mualani, Kachina,  and Kinichi's voice-overs.
     notesZh: "「花羽会」中的龙医",
     tags: [ "natlan", "character-sub" ],
   },

--- a/dataset/dictionary/items.json5
+++ b/dataset/dictionary/items.json5
@@ -1380,6 +1380,20 @@
     pronunciationJa: "ラクガキしゃしんき",
     tags: [ "natlan", "item", "event" ],
   },
+  {
+    en: "Paimon's Kamera",
+    ja: "パイモンの写真機",
+    zhCN: "派蒙的留影机",
+    pronunciationJa: "パイモンのしゃしんき",
+    tags: [ "natlan", "item", "event" ],
+  },
+  {
+    en: "Firstborn Firesprite",
+    ja: "新生の霊炎",
+    zhCN: "初诞灵焰",
+    pronunciationJa: "しんせいのれいえん",
+    tags: [ "item" ],
+  },
 
   //
   // Quest Items

--- a/dataset/dictionary/locations.json5
+++ b/dataset/dictionary/locations.json5
@@ -2492,7 +2492,7 @@
     en: "\"Flower-Feather Clan\"",
     ja: "「花翼の集」",
     zhCN: "「花羽会」",
-    pronunciationJa: "かよくのつどい", // Note: ふりがなについては魔神任務5章1部 帰火聖夜の巡礼、大会運営のパラムのチャスカ紹介ボイスを参考
+    pronunciationJa: "かよくのつどい", // Source of Japanese pronunciation: Introduction for Chasca by Balam, an organizer of Pilgrimage, in Archon Quest Chapter 5 Act 1
     tags: [ "natlan", "location", "organization" ],
   },
 

--- a/dataset/dictionary/locations.json5
+++ b/dataset/dictionary/locations.json5
@@ -2488,6 +2488,13 @@
     pronunciationJa: "とうえんしゃのひとう",
     tags: [ "natlan", "location" ],
   },
+  {
+    en: "\"Flower-Feather Clan\"",
+    ja: "「花翼の集」",
+    zhCN: "「花羽会」",
+    pronunciationJa: "かよくのつどい", // Note: ふりがなについては魔神任務5章1部 帰火聖夜の巡礼、大会運営のパラムのチャスカ紹介ボイスを参考
+    tags: [ "natlan", "location", "organization" ],
+  },
 
   //
   // Snezhnaya

--- a/dataset/dictionary/quests.json5
+++ b/dataset/dictionary/quests.json5
@@ -1601,6 +1601,13 @@
     pronunciationJa: "とあるフォンテーヌじんのおもいで",
     tags: [ "sumeru", "quest-world" ],
   },
+  {
+    en: "The Path of Papers",
+    ja: "学を求む長き道",
+    zhCN: "求学漫漫路",
+    pronunciationJa: "がくをもとむながきみち",
+    tags: [ "sumeru", "quest-world" ],
+  },
 
   // Fontaine
   {
@@ -3483,6 +3490,30 @@
     ja: "流行りの音楽",
     zhCN: "流行音乐，谁先知？",
     pronunciationJa: "はやりのおんがく",
+    tags: [ "quest-daily", "natlan" ],
+  },
+  {
+    en: "Daydream Club: Thermal Hypnosis",
+    ja: "空想クラブ・熱エネルギー睡眠導入",
+    zhCN: "空想俱乐部・热能催眠",
+    pronunciationJa: "くうそうクラブねつエネルギーすいみんどうにゅう",
+    tags: [ "quest-daily", "natlan" ],
+  },
+  {
+    en: "Grow Up Quickly, Littl'Un",
+    ja: "はやく大きくなーれ！",
+    zhCN: "小小人儿，快长大",
+    pronunciationJa: "はやくおおきくなーれ",
+    tags: [ "quest-daily", "natlan" ],
+  },
+  {
+    en: "Grow Up Quickly, Littl'Un...? (Epilogue)", // The original title does not have (Epilogue)
+    ja: "はやく大きくなーれ…？",
+    zhCN: "小小人儿，快长大…？",
+    notesEn: "The original title does not have (Epilogue). Added due to constraints of key generation.",
+    notes: "英語の原題には (Epilogue) はついていません。システム制約によりキーを重複させないための処置です。",
+    notesZh: "原英文标题不包括（Epilogue）。这是为了防止由于系统限制而出现重复密钥的措施。",
+    pronunciationJa: "はやくおおきくなーれ",
     tags: [ "quest-daily", "natlan" ],
   },
 

--- a/dataset/dictionary/quests.json5
+++ b/dataset/dictionary/quests.json5
@@ -3507,7 +3507,7 @@
     tags: [ "quest-daily", "natlan" ],
   },
   {
-    en: "Grow Up Quickly, Littl'Un...? (Epilogue)", // The original title does not have (Epilogue)
+    en: "Grow Up Quickly, Littl'Un...? (Epilogue)", // The original title does not have (Epilogue) ― TODO: Allow the same English title
     ja: "はやく大きくなーれ…？",
     zhCN: "小小人儿，快长大…？",
     notesEn: "The original title does not have (Epilogue). Added due to constraints of key generation.",

--- a/dataset/dictionary/y-events.json5
+++ b/dataset/dictionary/y-events.json5
@@ -234,6 +234,30 @@
     tags: [ "event", "weapon-material" ],
     notes: "v5.0 期間限定イベント「巡れ! ワンダフルグラフィティ」内で貰える配布武器「蒼紋の角杯」の強化アイテム",
   },
+  {
+    en: "Of Thorns and Crowns",
+    ja: "いばらと栄冠",
+    zhCN: "荆棘与勋冠",
+    pronunciationJa: "いばらとえいかん",
+    tags: [ "event" ],
+    notes: "v5.0 期間限定イベント",
+  },
+  {
+    en: "Mementos of Teyvat",
+    ja: "テイワットの思い出",
+    zhCN: "提瓦特忆画",
+    pronunciationJa: "テイワットのおもいで",
+    tags: [ "event" ],
+    notes: "4周年記念 期間限定イベント",
+  },
+  {
+    en: "A Honest Promotion",
+    ja: "良心的なキャンペーン",
+    zhCN: "善良促销",
+    pronunciationJa: "りょうしんてきなキャンペーン",
+    tags: [ "event", "quest-world" ],
+    notes: "4周年記念 期間限定のワールドクエスト",
+  },
 
   // v4.8
   {


### PR DESCRIPTION
Since we have advanced the story, we will add keywords. This time, I am creating it from Genshin Impact's "Archive" - "Travel Log", item, voice and movie.

Closes #310

Events
| English | Japanese | Chinese Simplifed | Note(ja)  | memo|
|---|---|---|---|---|
| Of Thorns and Crowns | いばらと栄冠 | 荆棘与勋冠 | v5.0 期間限定イベント | 
| Mementos of Teyvat  | テイワットの思い出 | 提瓦特忆画 | 4周年記念  期間限定イベント | 

Daily Quest
| English | Japanese | Chinese Simplifed | Note(en)  | memo|
|---|---|---|---|---|
| Daydream Club: Thermal Hypnosis | 空想クラブ・熱エネルギー睡眠導入 | 空想俱乐部・热能催眠
| Grow Up Quickly, Littl'Un | はやく大きくなーれ！ | 小小人儿，快长大
| Grow Up Quickly, Littl'Un...? *(Epilogue)* | はやく大きくなーれ…？ | 小小人儿，快长大…？ | The original title does not have *(Epilogue)*. Added due to constraints of key generation. | 「...」について、英語はドット3つ、他の言語は三点リーダー記号

World Quest
| English | Japanese | Chinese Simplifed | Note(en) | Note(ja)  | Note(zh-cn) | memo |
|---|---|---|---|---|---|---|
| The Path of Papers | 学を求む長き道 | 求学漫漫路 | ||| add tag:[sumeru] | 
| A Honest Promotion | 良心的なキャンペーン | 善良促销 | | 4周年記念 期間限定のワールドクエスト || add tag:[natlan, events] | 

Character (English and Simplified Chinese are temporary)
| English | Japanese | Chinese Simplifed | Note(en) | Note(ja) | Note(zh-cn) |Type | memo|
|---|---|---|---|---|---|---|---|
| 入力済み | アラニ | | Character appearing in many world quests, including ”And This Treasure Goes To...”, "The Path of Papers" | 「霊矩のお宝」「学を求む長き道」など、多くの世界任務に登場する人物 | 出现在「灵矩有宝予何人」，「求学漫漫路」等众多世界任务中的角色 |  NPC | add tag:[liyue, sumeru, natlan]
| Narzam | ナザム | 娜赞 | Character appearing in the world quest "The Path of Papers" | 世界任務「学を求む長き道」に登場する人物  | 世界任务「求学漫漫路」中出现的角色 | NPC | add tag:[sumeru, natlan]
| Ifa | イファ | 伊法 | Saurian vet from the "Flower-Feather Clan" | 「花翼の集」の竜医。タグのプレイアブル・NPC 分類は仮 | 「花羽会」中的龙医 | NPC | add tag:[natlan]<br>ムアラニ/カチーナ/キィニチのボイスでのみ出てくる人物
| Pyro Archon | 炎神(えんじん) | 火神| | | | - | add tags:[natlan, pyro, title]
| 入力済み | エゲリア | | | | | | del tag:[character-main]<br>add tags:[character-sub]
| Aloy | アーロイ | 埃洛伊 | Characters distributed in the Horizon collaboration during v2.1 | v2.1 中にホライゾンコラボで配布されたキャラクター | Horizon 合作版本 2.1 中的角色分布 | Playable | add tags:[events, character-main]

Item
| English | Japanese | Chinese Simplifed | Note(ja) | memo |
|---|---|---|---|---|
| Firstborn Firesprite | 新生の霊炎 | 初诞灵焰 ||  |
| Paimon's Kamera | パイモンの写真機 | 派蒙的留影机 |  | add tag[event]

Location
| English | Japanese | Chinese Simplifed | Note(ja) | memo |
|---|---|---|---|---|
| "Flower-Feather Clan" | 「花翼の集」(かよくのつどい) | 「花羽会」　|| add tags:[Organization] <br>ふりがなについては魔神任務5章1部 帰火聖夜の巡礼、大会運営のパラムのチャスカ紹介ボイスを参考 |
