### PR TITLE
Add Checking simplified Chinese characters

### DIFF
--- a/dataset/dictionary/characters.json5
+++ b/dataset/dictionary/characters.json5
@@ -533,7 +533,7 @@
   {
     en: "I. Ivanovna N.",
     ja: "I・イヴァノヴナ・N",
-    zhCN: "I・伊万诺夫娜・N",
+    zhCN: "I·伊万诺夫娜·N",
     tags: [ "mondstadt", "character-sub" ],
     notes: "魔女会・コードJ",
     notesZh: "魔女会代号J。",
@@ -544,7 +544,7 @@
     zhCN: "安德斯多特",
     tags: [ "mondstadt", "character-sub" ],
     notes: "魔女会・コードM。イノシシプリンセスの作者。フルネームは「アンヤ・M・アンデシュドッテル」(英: Anya M. Andersdotter, 簡中: 安雅·M·安德斯多特) と思われる", // Source of her fullname: Event movie in Simulanka in v4.8
-    notesZh: "魔女会代号M。《野猪公主》的作者。，安雅·M·安德斯多特 (英: Anya M. Andersdotter, 日: アンヤ・M・アンデシュドッテル) 似乎是全名",
+    notesZh: "魔女会代号M。《野猪公主》的作者。安雅·M·安德斯多特 (英: Anya M. Andersdotter, 日: アンヤ・M・アンデシュドッテル) 似乎是全名",
   },
   {
     en: "Nicole Reeyn",
@@ -4627,7 +4627,7 @@
   {
     en: "Morris",
     ja: "モリス",
-    zhCN: "モリス",
+    zhCN: "莫里斯",
     tags: [ "event", "fontaine", "character-sub" ],
     notes: "v4.3 期間限定イベント「薔薇と銃士」に登場する人物",
   },
@@ -4938,7 +4938,7 @@
   {
     en: "Toba",
     ja: "トバ",
-    zhCN: "トバ",
+    zhCN: "多巴",
     notes: "部族見聞「ユパンキの廻焔」に登場する人物",
     tags: [ "natlan", "character-sub" ],
   },

--- a/dataset/dictionary/living-beings.json5
+++ b/dataset/dictionary/living-beings.json5
@@ -526,7 +526,7 @@
   {
     en: "Flowfire Bird",
     ja: "浮燃ペンギン",
-    zhCN: "浮燃鳥",
+    zhCN: "浮燃鸟",
     tags: [ "natlan", "living-being" ],
   },
   {

--- a/dataset/dictionary/quests.json5
+++ b/dataset/dictionary/quests.json5
@@ -3495,7 +3495,7 @@
   {
     en: "Daydream Club: Thermal Hypnosis",
     ja: "空想クラブ・熱エネルギー睡眠導入",
-    zhCN: "空想俱乐部・热能催眠",
+    zhCN: "空想俱乐部·热能催眠",
     pronunciationJa: "くうそうクラブねつエネルギーすいみんどうにゅう",
     tags: [ "quest-daily", "natlan" ],
   },

--- a/tests/json5.test.js
+++ b/tests/json5.test.js
@@ -5,6 +5,39 @@ import { expect, test } from "vitest";
 import tags from "../dataset/tags.json";
 import words from "../dist/words.json";
 
+const japaneseChars = [
+  "・", // "·"
+  "鳥", // "鸟"
+  "竜", // "龙"
+  "災", // "灾"
+  "戦", // "战"
+  "猟", // "猎"
+  "風", // "风"
+  "楓", // "枫"
+  "隊", // "队"
+  "長", // "长"
+  "錬", // "炼"
+  "閉", // "闭"
+  "終", // "终"
+  "絶", // "绝"
+  "紛", // "纷"
+  "納", // "纳"
+  "緑", // "绿"
+  "約", // "约"
+  "綺", // "绮"
+  "鋸", // "锯"
+  "鳴", // "鸣"
+  "黒", // "黑"
+  "競", // "竞"
+  "場", // "场"
+  "尋", // "寻"
+  "茲", // "兹"
+  "駄", // "驮"
+  "獣", // "兽"
+  "霊", // "灵"
+  "聖", // "圣"
+];
+
 function isURL(urlStr) {
   try {
     new URL(urlStr);
@@ -180,6 +213,17 @@ test("if property values of dictionary JSON complies the format.", async () => {
           ok(isURL(example.refURL), `Invalid refURL of ${word.en}: ${example.refURL}`);
         }
       }
+    }
+
+    // Check simplified Chinese characters
+    if (!word.zhCN) {
+      return;
+    }
+
+    expect(word.zhCN).not.toMatch(/[ぁ-んァ-ヴー]/);
+
+    for (const jaChar of japaneseChars) {
+      expect(word.zhCN).not.toContain(jaChar);
     }
   }
 });


### PR DESCRIPTION
This is separate from version 5.1 support.
Simplified character check has been added to the test. Also, corrections have been made to items that were not allowed in the test.
https://github.com/xicri/genshin-langdata/issues/319

Daily Quest
| English | Japanese | Chinese Simplifed | Note(ja)  | memo|
|---|---|---|---|---|
| 入力済み | 空想クラブ・熱エネルギー睡眠導入 | 空想俱乐部·热能催眠 | | modified Chinese Simplifed 「・」→「·」

Character（NPC) of natlan
| English | Japanese | Chinese Simplifed | Note(en)  | Note(ja) | Note(zn-ch)  | type | memo |
|---|---|---|---|---|---|:-:|---|
| 入力済み | I・イヴァノヴナ・N | I·伊万诺夫娜·N | | | | |  modified Chinese Simplifed 「・」→「·」
| 入力済み | アンデシュドッテル | | | |魔女会代号M。《野猪公主》的作者。安雅·M·安德斯多特 (英: Anya M. Andersdotter, 日: アンヤ・M・アンデシュドッテル) 似乎是全名 | |  Remove unnecessary "，"
| 入力済み | モリス | 莫里斯 | | | | |  Sorry. It's a copy and paste mistake.
| 入力済み | トバ | 多巴 | | | | |  Sorry. It's a copy and paste mistake.

living
| English | Japanese | Chinese Simplifed | Note(en)  | Note(ja) | Note(zn-ch)  | type | memo |
|---|---|---|---|---|---|:-:|---|
| 入力済み | 浮燃ペンギン | 浮燃鸟 | | | | | sorry. typo "鳥"→"鸟"
