### PR TITLE
Add zhuyin alongside pinyin; several corrections

### DIFF
--- a/dataset/dictionary/artifacts.ts
+++ b/dataset/dictionary/artifacts.ts
@@ -174,6 +174,7 @@ export default [
       ja: [ "来歆" ],
     },
     pinyins: [{ char: "歆", pron: "xin1" }],
+    zhuyins: [{ char: "歆", pron: "ㄒㄧㄣ" }],
   },
   {
     en: "The Exile",
@@ -220,6 +221,7 @@ export default [
     },
     // Misread word
     pinyins: [{ char: "角", pron: "jue2" }, { char: "斗", pron: "dou4" }, { char: "士", pron: "shi4" }],
+    zhuyins: [{ char: "角", pron: "ㄐㄧㄠˇ" }, { char: "鬥", pron: "ㄉㄡˋ" }, { char: "士", pron: "ㄕˋ" }],
   },
   {
     en: "Golden Troupe",
@@ -352,6 +354,7 @@ export default [
       zhTW: [ "海染套" ],
     },
     pinyins: [{ char: "砗", pron: "che1" }, { char: "磲", pron: "qu2" }],
+    zhuyins: [{ char: "硨", pron: "ㄔㄜ" }, { char: "磲", pron: "ㄑㄩ" }],
   },
   {
     en: "Pale Flame",

--- a/dataset/dictionary/characters.ts
+++ b/dataset/dictionary/characters.ts
@@ -77,6 +77,7 @@ export default [
     zhTW: "嫣朵拉",
     tags: [ "character-sub", "item" ],
     pinyins: [{ char: "嫣", pron: "yan1" }],
+    zhuyins: [{ char: "嫣", pron: "ㄧㄢ" }],
   },
   {
     en: "Dandy",
@@ -518,6 +519,7 @@ export default [
     notes: "英語での発音は「ユーラ」",
     tags: [ "mondstadt", "character-main" ],
     pinyins: [{ char: "菈", pron: "la1" }],
+    zhuyins: [{ char: "菈", pron: "ㄌㄚ" }],
   },
   {
     en: "Spindrift Knight",
@@ -1132,6 +1134,7 @@ export default [
     pronunciationJa: "しんえん",
     tags: [ "liyue", "character-main" ],
     pinyins: [{ char: "焱", pron: "yan4" }],
+    zhuyins: [{ char: "焱", pron: "ㄧㄢˋ" }],
   },
   {
     en: "Zhongli",
@@ -1184,6 +1187,7 @@ export default [
     notes: "発音は「シァオ」([参考動画](https://youtu.be/p10yiwULJA8?t=310))",
     tags: [ "liyue", "character-main" ],
     pinyins: [{ char: "魈", pron: "xiao1" }],
+    zhuyins: [{ char: "魈", pron: "ㄒㄧㄠ" }],
   },
   {
     en: "Conqueror of Demons",
@@ -1271,6 +1275,7 @@ export default [
     tags: [ "liyue", "character-main" ],
     notes: "英語の発音は「バイジュ」",
     pinyins: [{ char: "术", pron: "zhu2" }],
+    zhuyins: [{ char: "朮", pron: "ㄓㄨˊ" }],
   },
   {
     en: "Dr. Baizhu",
@@ -1535,6 +1540,7 @@ export default [
       zhTW: [ "若陀" ],
     },
     pinyins: [{ char: "若", pron: "re3" }],
+    zhuyins: [{ char: "若", pron: "ㄖㄜˇ" }],
   },
   {
     en: "Guoba",
@@ -1671,6 +1677,7 @@ export default [
     zhTW: "掇星攫辰天君",
     tags: [ "liyue", "title" ],
     pinyins: [{ char: "掇", pron: "duo1" }, { char: "攫", pron: "jue2" }],
+    zhuyins: [{ char: "掇", pron: "ㄉㄨㄛ" }, { char: "攫", pron: "ㄐㄩㄝˊ" }],
   },
   {
     en: "Chef Mao",
@@ -2509,6 +2516,7 @@ export default [
     },
     tags: [ "inazuma", "character-main" ],
     pinyins: [{ char: "裟", pron: "sha1" }],
+    zhuyins: [{ char: "裟", pron: "ㄕㄚ" }],
   },
   {
     en: "Shikanoin Heizou",
@@ -2695,6 +2703,7 @@ export default [
     pronunciationJa: "ひいらぎひろし",
     tags: [ "inazuma", "character-sub" ],
     pinyins: [{ char: "柊", pron: "zhong1" }],
+    zhuyins: [{ char: "柊", pron: "ㄓㄨㄥ" }],
   },
   {
     en: "Wakamurasaki",
@@ -2763,6 +2772,7 @@ export default [
     zhTW: "阿瑠",
     tags: [ "inazuma", "character-sub" ],
     pinyins: [{ char: "瑠", pron: "liu2" }],
+    zhuyins: [{ char: "瑠", pron: "ㄌㄧㄡˊ" }],
   },
   {
     en: "Kama",
@@ -3027,6 +3037,7 @@ export default [
     tags: [ "inazuma", "character-sub" ],
     notes: "稲妻の漁師",
     pinyins: [{ char: "椛", pron: "hua1" }],
+    zhuyins: [{ char: "椛", pron: "ㄏㄨㄚ" }],
     notesEn: "Inazuman Angler",
   },
   {
@@ -3865,6 +3876,7 @@ export default [
     notes: "世界任務「翼の折れた猟鷹」「過ぎ去りし終末」などに登場するキャラクター。タニット部族の1人。マシーラの娘。",
     notesZh: "世界任务「翅膀折断的猎鹰」「已逝去的末日」中登场的角色。塔尼特部族的成员之一。马塞拉的女儿。",
     pinyins: [{ char: "菈", pron: "la1" }],
+    zhuyins: [{ char: "菈", pron: "ㄌㄚ" }],
   },
   {
     en: "Masseira",
@@ -4122,6 +4134,7 @@ export default [
     zhTW: "蘭耆都",
     tags: [ "sumeru", "character-sub" ],
     pinyins: [{ char: "耆", pron: "qi2" }],
+    zhuyins: [{ char: "耆", pron: "ㄑㄧˊ" }],
   },
   {
     en: "Aramuhukunda",
@@ -4370,6 +4383,7 @@ export default [
     notes: "ソルシュが旅人に任じた記録者としての役割",
     notesZh: "斯露莎给旅行者的称号",
     pinyins: [{ char: "谒", pron: "ye4" }],
+    zhuyins: [{ char: "謁", pron: "ㄧㄝˋ" }],
   },
   {
     en: "Nasejuna",
@@ -8442,6 +8456,7 @@ export default [
     zhTW: "白鵠騎士",
     tags: [ "khaenriah", "title" ],
     pinyins: [{ char: "鹄", pron: "hu2" }],
+    zhuyins: [{ char: "鵠", pron: "ㄏㄨˊ" }],
   },
   {
     en: "Hroptatyr",

--- a/dataset/dictionary/dialogue.ts
+++ b/dataset/dictionary/dialogue.ts
@@ -246,6 +246,7 @@ export default [
     zhTW: "靖妖儺舞",
     pronunciationJa: "せいようなぶ",
     pinyins: [{ char: "傩", pron: "nuo2" }],
+    zhuyins: [{ char: "儺", pron: "ㄋㄨㄛˊ" }],
     notes: "魈の元素爆発発動時のセリフ。「西洋鍋」という空耳で有名。",
     tags: [ "dialogue" ],
     variants: {

--- a/dataset/dictionary/domains.ts
+++ b/dataset/dictionary/domains.ts
@@ -252,6 +252,7 @@ export default [
     },
     tags: [ "liyue", "domain" ],
     pinyins: [{ char: "岫", pron: "xiu4" }],
+    zhuyins: [{ char: "岫", pron: "ㄒㄧㄡˋ" }],
   },
   {
     en: "Hidden Palace of Zhou Formula",
@@ -345,6 +346,7 @@ export default [
     pronunciationJa: "すみれいろノにわ",
     tags: [ "inazuma", "domain" ],
     pinyins: [{ char: "堇", pron: "jin3" }],
+    zhuyins: [{ char: "堇", pron: "ㄐㄧㄣˇ" }],
   },
   {
     en: "Court of Flowing Sand",
@@ -377,6 +379,7 @@ export default [
     pronunciationJa: "もみじノにわ",
     tags: [ "inazuma", "domain" ],
     pinyins: [{ char: "椛", pron: "hua1" }],
+    zhuyins: [{ char: "椛", pron: "ㄏㄨㄚ" }],
   },
   {
     en: "Formation Estate",
@@ -428,6 +431,7 @@ export default [
     tags: [ "inazuma", "domain" ],
     notes: "禍津御建鳴神命戦の秘境名。",
     pinyins: [{ char: "殁", pron: "mo4" }],
+    zhuyins: [{ char: "殁", pron: "ㄇㄛˋ" }],
   },
 
   //

--- a/dataset/dictionary/drops-boss.ts
+++ b/dataset/dictionary/drops-boss.ts
@@ -64,6 +64,7 @@ export default [
     tags: [ "drop-boss", "sumeru" ],
     notes: "無相の草のドロップアイテム。滅諍とは仏教の戒律の一種で、僧団内での裁判規定のようなもの。参照: [Wikipedia](https://ja.wikipedia.org/wiki/%E6%BB%85%E8%AB%8D)",
     pinyins: [{ char: "诤", pron: "zheng4" }],
+    zhuyins: [{ char: "諍", pron: "ㄓㄥˋ" }],
   },
   {
     en: "Hoarfrost Core",
@@ -169,6 +170,7 @@ export default [
     tags: [ "drop-boss", "sumeru" ],
     notes: "マッシュラプトルのドロップアイテム",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Perpetual Caliber",
@@ -348,6 +350,7 @@ export default [
     tags: [ "drop-boss", "liyue" ],
     notes: "若陀龍王のドロップアイテム",
     pinyins: [{ char: "鎏", pron: "liu2" }],
+    zhuyins: [{ char: "鎏", pron: "ㄌㄧㄡˊ" }],
   },
   // La Signora
   {
@@ -394,6 +397,7 @@ export default [
     tags: [ "drop-boss", "inazuma" ],
     notes: "禍津御建鳴神命のドロップアイテム",
     pinyins: [{ char: "禊", pron: "xi4" }],
+    zhuyins: [{ char: "禊", pron: "ㄒㄧˋ" }],
   },
   {
     en: "The Meaning of Aeons",
@@ -456,6 +460,7 @@ export default [
     tags: [ "drop-boss", "sumeru" ],
     notes: "アペプのオアシス守護者のドロップアイテム",
     pinyins: [{ char: "亘", pron: "gen4" }],
+    zhuyins: [{ char: "亙", pron: "ㄍㄣˋ" }],
   },
   {
     en: "Lightless Silk String",

--- a/dataset/dictionary/drops.ts
+++ b/dataset/dictionary/drops.ts
@@ -413,6 +413,7 @@ export default [
     tags: [ "drop" ],
     notes: "宝盗団のドロップアイテム (★3)",
     pinyins: [{ char: "擢", pron: "zhuo2" }],
+    zhuyins: [{ char: "擢", pron: "ㄓㄨㄛˊ" }],
   },
   {
     en: "Silver Raven Insignia",
@@ -467,6 +468,7 @@ export default [
     tags: [ "drop", "inazuma" ],
     notes: "野伏衆のドロップアイテム (★1)",
     pinyins: [{ char: "镡", pron: "xin2" }],
+    zhuyins: [{ char: "鐔", pron: "ㄒㄧㄣˊ" }],
   },
   {
     en: "Kageuchi Handguard",
@@ -477,6 +479,7 @@ export default [
     tags: [ "drop", "inazuma" ],
     notes: "野伏衆のドロップアイテム (★2)",
     pinyins: [{ char: "镡", pron: "xin2" }],
+    zhuyins: [{ char: "鐔", pron: "ㄒㄧㄣˊ" }],
   },
   {
     en: "Famed Handguard",
@@ -487,6 +490,7 @@ export default [
     tags: [ "drop", "inazuma" ],
     notes: "野伏衆のドロップアイテム (★3)",
     pinyins: [{ char: "镡", pron: "xin2" }],
+    zhuyins: [{ char: "鐔", pron: "ㄒㄧㄣˊ" }],
   },
   {
     en: "Concealed Claw",
@@ -521,6 +525,7 @@ export default [
     tags: [ "drop", "sumeru" ],
     notes: "キノコンのドロップアイテム (★1)",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Luminescent Pollen",
@@ -583,6 +588,7 @@ export default [
     tags: [ "drop" ],
     notes: "黒蛇衆のドロップアイテム (★3)",
     pinyins: [{ char: "夤", pron: "yin2" }],
+    zhuyins: [{ char: "夤", pron: "ㄧㄣˊ" }],
   },
   {
     en: "Deathly Statuette",
@@ -668,6 +674,7 @@ export default [
     tags: [ "drop" ],
     notes: "聖骸獣のドロップアイテム (★4)",
     pinyins: [{ char: "锲", pron: "qie4" }],
+    zhuyins: [{ char: "鍥", pron: "ㄑㄧㄝˋ" }],
   },
   {
     en: "A Flower Yet to Bloom",

--- a/dataset/dictionary/enemies.ts
+++ b/dataset/dictionary/enemies.ts
@@ -539,6 +539,7 @@ export default [
     pronunciationJa: "いせきじゅんししゃ",
     tags: [ "enemy" ],
     pinyins: [{ char: "弋", pron: "yi4" }],
+    zhuyins: [{ char: "弋", pron: "ㄧˋ" }],
   },
   {
     en: "Ruin Scout",
@@ -934,6 +935,7 @@ export default [
       zhTW: [ "火槍" ],
     },
     pinyins: [{ char: "铳", pron: "chong4" }],
+    zhuyins: [{ char: "銃", pron: "ㄔㄨㄥˋ" }],
   },
   {
     en: "Fatui Skirmisher - Geochanter Bracer",
@@ -961,6 +963,7 @@ export default [
       zhTW: [ "冰槍" ],
     },
     pinyins: [{ char: "铳", pron: "chong4" }],
+    zhuyins: [{ char: "銃", pron: "ㄔㄨㄥˋ" }],
   },
   {
     en: "Fatui Skirmisher - Hydrogunner Legionnaire",
@@ -975,6 +978,7 @@ export default [
       zhTW: [ "水胖" ],
     },
     pinyins: [{ char: "铳", pron: "chong4" }],
+    zhuyins: [{ char: "銃", pron: "ㄔㄨㄥˋ" }],
   },
   {
     en: "Fatui Skirmisher - Anemoboxer Vanguard",
@@ -1412,6 +1416,7 @@ export default [
     pronunciationJa: "ばっせい",
     tags: [ "enemy-boss", "liyue" ],
     pinyins: [{ char: "跋", pron: "ba2" }, { char: "掣", pron: "che4" }],
+    zhuyins: [{ char: "跋", pron: "ㄅㄚˊ" }, { char: "掣", pron: "ㄔㄜˋ" }],
   },
   {
     en: "The Avenger of the Vortex",
@@ -1649,6 +1654,7 @@ export default [
     pronunciationJa: "こくじゃきし・さいがんのおの", // TODO Need Check
     tags: [ "enemy" ],
     pinyins: [{ char: "钺", pron: "yue4" }],
+    zhuyins: [{ char: "鉞", pron: "ㄩㄝˋ" }],
   },
   {
     en: "The Black Serpents",
@@ -1668,6 +1674,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Fungi で、原義は「菌類」。",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Floating Hydro Fungus",
@@ -1677,6 +1684,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Floating Hydro Fungi。",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Floating Dendro Fungus",
@@ -1686,6 +1694,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Floating Dendro Fungi。",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Stretchy Anemo Fungus",
@@ -1695,6 +1704,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Stretchy Anemo Fungi と思われる。",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Stretchy Geo Fungus",
@@ -1704,6 +1714,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Stretchy Geo Fungi と思われる。",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Stretchy Pyro Fungus",
@@ -1713,6 +1724,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Stretchy Pyro Fungi と思われる。",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Whirling Electro Fungus",
@@ -1722,6 +1734,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Whirling Electro Fungi と思われる。",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Whirling Cryo Fungus",
@@ -1731,6 +1744,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Whirling Cryo Fungi と思われる。",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Whirling Pyro Fungus",
@@ -1740,6 +1754,7 @@ export default [
     tags: [ "enemy", "sumeru" ],
     notes: "英語の複数形は Whirling Pyro Fungi と思われる",
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Grounded Hydroshroom",
@@ -1748,6 +1763,7 @@ export default [
     zhTW: "陸行水本真蕈",
     tags: [ "enemy", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Grounded Geoshroom",
@@ -1756,6 +1772,7 @@ export default [
     zhTW: "陸行巖本真蕈",
     tags: [ "enemy", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Winged Dendroshroom",
@@ -1764,6 +1781,7 @@ export default [
     zhTW: "有翼草本真蕈",
     tags: [ "enemy", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Winged Cryoshroom",
@@ -1772,6 +1790,7 @@ export default [
     zhTW: "有翼冰本真蕈",
     tags: [ "enemy", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Jadeplume Terrorshroom",
@@ -1780,6 +1799,7 @@ export default [
     zhTW: "翠翎恐蕈",
     tags: [ "enemy-boss", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
 
   {

--- a/dataset/dictionary/foods.ts
+++ b/dataset/dictionary/foods.ts
@@ -168,6 +168,7 @@ export default [
     },
     tags: [ "food" ],
     pinyins: [{ char: "噌", pron: "ceng1" }],
+    zhuyins: [{ char: "噌", pron: "ㄔㄥ" }],
   },
   {
     en: "Soba Noodles",
@@ -848,6 +849,7 @@ export default [
     zhTW: "醃篤鮮",
     tags: [ "food" ],
     pinyins: [{ char: "笃", pron: "du3" }],
+    zhuyins: [{ char: "篤", pron: "ㄉㄨˇ" }],
   },
   {
     en: "Jade Fruit Soup",
@@ -1044,6 +1046,7 @@ export default [
     pronunciationJa: "こんだに",
     tags: [ "food" ],
     pinyins: [{ char: "绀", pron: "gan4" }],
+    zhuyins: [{ char: "紺", pron: "ㄍㄢˋ" }],
   },
   {
     en: "Sakura Mochi",
@@ -1918,6 +1921,7 @@ export default [
     tags: [ "food", "liyue" ],
     notes: "鍾離のオリジナル料理",
     pinyins: [{ char: "笃", pron: "du3" }],
+    zhuyins: [{ char: "篤", pron: "ㄉㄨˇ" }],
   },
   {
     en: "Ghostly March",
@@ -2171,6 +2175,7 @@ export default [
     zhTW: "憧憬",
     pronunciationJa: "あこがれ",
     pinyins: [{ char: "憧", pron: "chong1" }, { char: "憬", pron: "jing3" }],
+    zhuyins: [{ char: "憧", pron: "ㄔㄨㄥ" }, { char: "憬", pron: "ㄐㄧㄥˇ" }],
     tags: [ "food", "sumeru" ],
     notes: "コレイのオリジナル料理",
   },
@@ -2738,6 +2743,7 @@ export default [
     zhTW: "星蕈",
     tags: [ "food", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Activated Starshroom",
@@ -2746,6 +2752,7 @@ export default [
     zhTW: "活化的星蕈",
     tags: [ "food", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Scorched Starshroom",
@@ -2754,6 +2761,7 @@ export default [
     zhTW: "枯焦的星蕈",
     tags: [ "food", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Zaytun Peach",

--- a/dataset/dictionary/items.ts
+++ b/dataset/dictionary/items.ts
@@ -306,6 +306,7 @@ export default [
     pronunciationJa: "りーゆぇのちれいだんのかぎ",
     tags: [ "item", "liyue" ],
     pinyins: [{ char: "龛", pron: "kan1" }],
+    zhuyins: [{ char: "龕", pron: "ㄎㄢ" }],
   },
   {
     en: "Fontaine Shrine of Depths Key",
@@ -315,6 +316,7 @@ export default [
     pronunciationJa: "フォンテーヌのちれいだんのかぎ",
     tags: [ "item", "fontaine" ],
     pinyins: [{ char: "龛", pron: "kan1" }],
+    zhuyins: [{ char: "龕", pron: "ㄎㄢ" }],
   },
   {
     en: "Adepti Seeker's Stove",
@@ -451,6 +453,7 @@ export default [
     pronunciationJa: "きんきめっきゃくのふだ",
     tags: [ "item", "liyue" ],
     pinyins: [{ char: "箓", pron: "lu4" }],
+    zhuyins: [{ char: "籙", pron: "ㄌㄨˋ" }],
   },
   {
     en: "Memento Lens",
@@ -548,6 +551,7 @@ export default [
     zhTW: "歲時之晷",
     tags: [ "item", "liyue" ],
     pinyins: [{ char: "晷", pron: "gui3" }],
+    zhuyins: [{ char: "晷", pron: "ㄍㄨㄟˇ" }],
   },
   {
     en: "Cup of Commons",
@@ -978,6 +982,7 @@ export default [
     zhTW: "花鱂",
     tags: [ "item" ],
     pinyins: [{ char: "鳉", pron: "jiang1" }],
+    zhuyins: [{ char: "鱂", pron: "ㄐㄧㄤ" }],
   },
   {
     en: "Glaze Medaka",
@@ -986,6 +991,7 @@ export default [
     zhTW: "琉璃花鱂",
     tags: [ "item" ],
     pinyins: [{ char: "鳉", pron: "jiang1" }],
+    zhuyins: [{ char: "鱂", pron: "ㄐㄧㄤ" }],
   },
   {
     en: "Sweet-Flower Medaka",
@@ -994,6 +1000,7 @@ export default [
     zhTW: "甜甜花鱂",
     tags: [ "item" ],
     pinyins: [{ char: "鳉", pron: "jiang1" }],
+    zhuyins: [{ char: "鱂", pron: "ㄐㄧㄤ" }],
   },
   {
     en: "Aizen Medaka",
@@ -1003,6 +1010,7 @@ export default [
     pronunciationJa: "あいぜんグッピー",
     tags: [ "item" ],
     pinyins: [{ char: "鳉", pron: "jiang1" }],
+    zhuyins: [{ char: "鱂", pron: "ㄐㄧㄤ" }],
   },
   {
     en: "Crystalfish",
@@ -1057,6 +1065,7 @@ export default [
     zhTW: "鴆棘魚",
     tags: [ "item" ],
     pinyins: [{ char: "鸩", pron: "zhen4" }],
+    zhuyins: [{ char: "鴆", pron: "ㄓㄣˋ" }],
   },
   {
     en: "Divda Ray",
@@ -1144,6 +1153,7 @@ export default [
     pronunciationJa: "さびいろリュウノコ",
     tags: [ "item" ],
     pinyins: [{ char: "锖", pron: "qiang1" }],
+    zhuyins: [{ char: "錆", pron: "ㄑㄧㄤ" }],
   },
   {
     en: "Pufferfish",
@@ -1449,6 +1459,7 @@ export default [
     zhTW: "䴉巷物語",
     tags: [ "item", "inazuma" ],
     pinyins: [{ char: "鹮", pron: "huan2" }],
+    zhuyins: [{ char: "䴉", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "New Chronicles of the Six Kitsune",
@@ -1703,6 +1714,7 @@ export default [
     zhTW: "苦舍桓",
     tags: [ "item", "sumeru" ],
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Scarlet Sand Slate",
@@ -1834,6 +1846,7 @@ export default [
     pronunciationJa: "そせいたづな",
     tags: [ "item", "inazuma" ],
     pinyins: [{ char: "辔", pron: "pei4" }],
+    zhuyins: [{ char: "轡", pron: "ㄆㄟˋ" }],
   },
   {
     en: "Divine Bridle",
@@ -1843,6 +1856,7 @@ export default [
     pronunciationJa: "みこしたづな",
     tags: [ "item", "inazuma" ],
     pinyins: [{ char: "辔", pron: "pei4" }],
+    zhuyins: [{ char: "轡", pron: "ㄆㄟˋ" }],
   },
   {
     en: "Waters of Lethe",
@@ -1875,6 +1889,7 @@ export default [
     zhTW: "桓斯彌利底",
     tags: [ "item", "sumeru" ],
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Vasoma Fruit",
@@ -1883,6 +1898,7 @@ export default [
     zhTW: "恆素果",
     tags: [ "item", "sumeru" ],
     pinyins: [{ char: "恒", pron: "heng2" }],
+    zhuyins: [{ char: "恆", pron: "ㄏㄥˊ" }],
   },
   {
     en: "Barsam Flower",
@@ -1892,6 +1908,7 @@ export default [
     tags: [ "item", "sumeru" ],
     notes: "世界任務「アグニホトラ経」終章で作るアランハオマの原料の1つ",
     pinyins: [{ char: "钵", pron: "bo1" }],
+    zhuyins: [{ char: "缽", pron: "ㄅㄛ" }],
   },
   {
     en: "Arahaoma",
@@ -1951,6 +1968,7 @@ export default [
     zhTW: "淨光翎",
     tags: [ "item", "sumeru" ],
     pinyins: [{ char: "翎", pron: "ling2" }],
+    zhuyins: [{ char: "翎", pron: "ㄌㄧㄥˊ" }],
   },
   {
     en: "Korybantes",
@@ -2284,6 +2302,7 @@ export default [
     pronunciationJa: "げいきょのまい",
     notes: "刻晴のコスチューム",
     pinyins: [{ char: "跹", pron: "xian1" }],
+    zhuyins: [{ char: "躚", pron: "ㄒㄧㄢ" }],
   },
   {
     en: "Orchid's Evening Gown",
@@ -2300,6 +2319,7 @@ export default [
     zhTW: "殷紅終夜",
     notes: "ディルックのコスチューム",
     pinyins: [{ char: "殷", pron: "yan1" }],
+    zhuyins: [{ char: "殷", pron: "ㄧㄣ" }],
   },
   {
     en: "Ein Immernachtstraum",

--- a/dataset/dictionary/living-beings.ts
+++ b/dataset/dictionary/living-beings.ts
@@ -142,6 +142,7 @@ export default [
     zhTW: "蕈豬",
     tags: [ "living-being", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Weasel Thief",
@@ -309,6 +310,7 @@ export default [
     pronunciationJa: "だじゅう",
     tags: [ "living-being", "enemy", "sumeru" ],
     pinyins: [{ char: "驮", pron: "tuo2" }],
+    zhuyins: [{ char: "馱", pron: "ㄊㄨㄛˊ" }],
   },
   {
     en: "Shaggy Sumpter Beast",
@@ -318,6 +320,7 @@ export default [
     pronunciationJa: "モジャモジャだじゅう",
     tags: [ "living-being", "enemy", "sumeru" ],
     pinyins: [{ char: "牦", pron: "mao2" }, { char: "驮", pron: "tuo2" }],
+    zhuyins: [{ char: "犛", pron: "ㄇㄠˊ" }, { char: "馱", pron: "ㄊㄨㄛˊ" }],
   },
   {
     en: "Desert Sumpter Beast",
@@ -378,6 +381,7 @@ export default [
     zhTW: "長鬢虎羅闍",
     tags: [ "living-being", "enemy", "sumeru" ],
     pinyins: [{ char: "阇", pron: "du1" }],
+    zhuyins: [{ char: "闍", pron: "ㄉㄨ" }],
   },
   {
     en: "Sumpter Beastlord",
@@ -467,6 +471,7 @@ export default [
     zhTW: "玳龜",
     tags: [ "living-being", "sumeru" ],
     pinyins: [{ char: "玳", pron: "dai4" }],
+    zhuyins: [{ char: "玳", pron: "ㄉㄞˋ" }],
   },
 
   //
@@ -489,6 +494,7 @@ export default [
     zhCN: "美露莘",
     zhTW: "美露莘",
     pinyins: [{ char: "莘", pron: "xin1" }],
+    zhuyins: [{ char: "莘", pron: "ㄒㄧㄣ" }],
     tags: [ "fontaine", "living-being" ],
   },
   {

--- a/dataset/dictionary/locations.ts
+++ b/dataset/dictionary/locations.ts
@@ -156,6 +156,7 @@ export default [
     pronunciationJa: "ちかいのみさき",
     tags: [ "mondstadt", "location" ],
     pinyins: [{ char: "岬", pron: "jia3" }],
+    zhuyins: [{ char: "岬", pron: "ㄐㄧㄚˇ" }],
   },
 
   {
@@ -358,6 +359,7 @@ export default [
     pronunciationJa: "ちこがん",
     tags: [ "liyue", "location" ],
     pinyins: [{ char: "螭", pron: "chi1" }],
+    zhuyins: [{ char: "螭", pron: "ㄔ" }],
   },
   {
     en: "Jade Chamber",
@@ -382,6 +384,7 @@ export default [
     zhTW: "珠鈿舫",
     tags: [ "liyue", "facility" ],
     pinyins: [{ char: "钿", pron: "dian4" }, { char: "舫", pron: "fang3" }],
+    zhuyins: [{ char: "鈿", pron: "ㄉㄧㄢˋ" }, { char: "舫", pron: "ㄈㄤˇ" }],
   },
   {
     en: "Golden House",
@@ -485,6 +488,7 @@ export default [
       ja: [ "びんりん" ],
     },
     pinyins: [{ char: "珉", pron: "min2" }],
+    zhuyins: [{ char: "珉", pron: "ㄇㄧㄣˊ" }],
   },
   {
     en: "Luhua Pool",
@@ -494,6 +498,7 @@ export default [
     pronunciationJa: "ろくかのいけ",
     tags: [ "liyue", "location" ],
     pinyins: [{ char: "渌", pron: "lu4" }],
+    zhuyins: [{ char: "淥", pron: "ㄌㄨˋ" }],
   },
   {
     en: "Tianqiu Valley",
@@ -511,6 +516,7 @@ export default [
     pronunciationJa: "すいけつざか",
     tags: [ "liyue", "location" ],
     pinyins: [{ char: "玦", pron: "jue2" }],
+    zhuyins: [{ char: "玦", pron: "ㄐㄩㄝˊ" }],
   },
   {
     en: "Jueyun Karst",
@@ -560,6 +566,7 @@ export default [
     pronunciationJa: "おくぞうさん",
     tags: [ "liyue", "location" ],
     pinyins: [{ char: "藏", pron: "cang2" }],
+    zhuyins: [{ char: "藏", pron: "ㄘㄤˊ" }],
   },
 
   {
@@ -586,6 +593,7 @@ export default [
     pronunciationJa: "てきかしゅう",
     tags: [ "liyue", "location" ],
     pinyins: [{ char: "荻", pron: "di2" }],
+    zhuyins: [{ char: "荻", pron: "ㄉㄧˊ" }],
   },
   {
     en: "Stone Gate",
@@ -933,6 +941,7 @@ export default [
     pronunciationJa: "こんだむら",
     tags: [ "inazuma", "location" ],
     pinyins: [{ char: "绀", pron: "gan4" }],
+    zhuyins: [{ char: "紺", pron: "ㄍㄢˋ" }],
   },
   {
     en: "Byakko Plain",
@@ -1015,6 +1024,7 @@ export default [
     pronunciationJa: "たたらすな",
     tags: [ "inazuma", "location" ],
     pinyins: [{ char: "鞴", pron: "bei4" }],
+    zhuyins: [{ char: "鞴", pron: "ㄅㄟˋ" }],
   },
   {
     en: "Mikage Furnace",
@@ -1041,6 +1051,7 @@ export default [
     pronunciationJa: "なづちのはま",
     tags: [ "inazuma", "location" ],
     pinyins: [{ char: "椎", pron: "zhui1" }],
+    zhuyins: [{ char: "椎", pron: "ㄓㄨㄟ" }],
   },
 
   {
@@ -1051,6 +1062,7 @@ export default [
     pronunciationJa: "ヤシオリじま",
     tags: [ "inazuma", "location" ],
     pinyins: [{ char: "酝", pron: "yun4" }],
+    zhuyins: [{ char: "醞", pron: "ㄩㄣˋ" }],
   },
   {
     en: "Musoujin Gorge",
@@ -1071,6 +1083,7 @@ export default [
     pronunciationJa: "ふじとうとりで",
     tags: [ "inazuma", "location", "facility" ],
     pinyins: [{ char: "砦", pron: "zhai4" }],
+    zhuyins: [{ char: "砦", pron: "ㄓㄞˋ" }],
   },
   {
     en: "Fort Mumei",
@@ -1080,6 +1093,7 @@ export default [
     pronunciationJa: "むみょうとりで",
     tags: [ "inazuma", "location" ],
     pinyins: [{ char: "砦", pron: "zhai4" }],
+    zhuyins: [{ char: "砦", pron: "ㄓㄞˋ" }],
   },
   {
     en: "Higi Village",
@@ -1114,6 +1128,7 @@ export default [
     pronunciationJa: "わたつみじま",
     tags: [ "inazuma", "location" ],
     pinyins: [{ char: "祇", pron: "qi2" }],
+    zhuyins: [{ char: "祇", pron: "ㄑㄧˊ" }],
   },
   {
     en: "Sangonomiya Shrine",
@@ -1221,6 +1236,7 @@ export default [
     pronunciationJa: "ひらうみとりで",
     tags: [ "inazuma", "location" ],
     pinyins: [{ char: "砦", pron: "zhai4" }],
+    zhuyins: [{ char: "砦", pron: "ㄓㄞˋ" }],
   },
   {
     en: "Koseki Village",
@@ -1256,6 +1272,7 @@ export default [
     zhTW: "天雲峠",
     pronunciationJa: "あまくもとうげ",
     pinyins: [{ char: "峠", pron: "qia3" }],
+    zhuyins: [{ char: "峠", pron: "ㄑㄧㄚˇ" }],
     tags: [ "inazuma", "location" ],
   },
 
@@ -1307,6 +1324,7 @@ export default [
     pronunciationJa: "カンナざん",
     tags: [ "inazuma", "location" ],
     pinyins: [{ char: "菅", pron: "jian1" }],
+    zhuyins: [{ char: "菅", pron: "ㄐㄧㄢ" }],
   },
   {
     en: "Moshiri Ceremonial Site",
@@ -1487,6 +1505,7 @@ export default [
     pronunciationJa: "チャトラカムどうくつ",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
 
   {
@@ -1511,6 +1530,7 @@ export default [
     pronunciationJa: "ヤスナゆうきょう",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "谒", pron: "ye4" }],
+    zhuyins: [{ char: "謁", pron: "ㄧㄝˋ" }],
   },
   {
     en: "Apam Woods",
@@ -1577,6 +1597,7 @@ export default [
     zhTW: "桓那蘭那",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Mahavanaranapna",
@@ -1586,6 +1607,7 @@ export default [
     tags: [ "sumeru", "location" ],
     notes: "アランナラの言葉で、夢の中のヴァナラーナを指す",
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
 
   {
@@ -1603,6 +1625,7 @@ export default [
     zhTW: "往昔的桓那蘭那",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Sand-Embraced Home",
@@ -1750,6 +1773,7 @@ export default [
     pronunciationJa: "しゃくせきのおか",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "铄", pron: "shuo4" }],
+    zhuyins: [{ char: "鑠", pron: "ㄕㄨㄛˋ" }],
   },
   {
     en: "The Mausoleum of King Deshret",
@@ -1866,6 +1890,7 @@ export default [
     pronunciationJa: "アル・アジフのすな",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "啁", pron: "zhao1" }, { char: "哳", pron: "zha1" }],
+    zhuyins: [{ char: "啁", pron: "ㄓㄠ" }, { char: "哳", pron: "ㄓㄚ" }],
   },
   {
     en: "Qusayr Al-Inkhida'",
@@ -1883,6 +1908,7 @@ export default [
     pronunciationJa: "せいこうのさきゅう",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "镔", pron: "bin1" }],
+    zhuyins: [{ char: "鑌", pron: "ㄅㄧㄣ" }],
   },
   {
     en: "Mt. Damavand",
@@ -1963,6 +1989,7 @@ export default [
     pronunciationJa: "アル・スークルきゅうでん",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "酣", pron: "han1" }, { char: "乐", pron: "le4" }],
+    zhuyins: [{ char: "酣", pron: "ㄏㄢ" }, { char: "樂", pron: "ㄌㄜˋ" }],
   },
   {
     en: "Deshret's Glass Goblet",
@@ -1989,6 +2016,7 @@ export default [
     zhTW: "蒼漠囿土",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "囿", pron: "you4" }],
+    zhuyins: [{ char: "囿", pron: "ㄧㄡˋ" }],
   },
 
   {
@@ -2048,6 +2076,7 @@ export default [
     zhTW: "浮羅囿",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "囿", pron: "you4" }],
+    zhuyins: [{ char: "囿", pron: "ㄧㄡˋ" }],
   },
   {
     en: "Vourukasha Oasis",
@@ -2074,6 +2103,7 @@ export default [
     pronunciationJa: "バルソムのおか",
     tags: [ "sumeru", "location" ],
     pinyins: [{ char: "跋", pron: "ba2" }],
+    zhuyins: [{ char: "跋", pron: "ㄅㄚˊ" }],
   },
   {
     en: "Tulaytullah",

--- a/dataset/dictionary/objects.ts
+++ b/dataset/dictionary/objects.ts
@@ -485,6 +485,7 @@ export default [
     pronunciationJa: "ヴァナラーナのゆめのき",
     tags: [ "object", "sumeru" ],
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Vasara Tree",
@@ -607,6 +608,7 @@ export default [
     tags: [ "object", "sumeru" ],
     notes: "洞窟などの入り口を塞いでおり、ライアーの演奏と攻撃により回転して道を開けることができる球状のオブジェクト",
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Zohrah Mushroom",
@@ -615,6 +617,7 @@ export default [
     zhTW: "須羅蕈",
     tags: [ "object", "sumeru" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Jamikayomars",
@@ -848,6 +851,7 @@ export default [
     pronunciationJa: "ジンニーのほこら",
     tags: [ "object", "sumeru" ],
     pinyins: [{ char: "龛", pron: "kan1" }],
+    zhuyins: [{ char: "龕", pron: "ㄎㄢ" }],
   },
   {
     en: "Jinn Branch",
@@ -925,6 +929,7 @@ export default [
     tags: [ "object", "sumeru" ],
     notes: "ソルシュが開花させることで足場になる花",
     pinyins: [{ char: "芸", pron: "yun2" }],
+    zhuyins: [{ char: "芸", pron: "ㄩㄣˊ" }],
   },
   {
     en: "Sunyata Flower",
@@ -976,6 +981,7 @@ export default [
     tags: [ "object", "sumeru" ],
     notes: "バルソムの丘にある古樹",
     pinyins: [{ char: "跋", pron: "ba2" }],
+    zhuyins: [{ char: "跋", pron: "ㄅㄚˊ" }],
   },
   {
     en: "Soul Bell",
@@ -986,6 +992,7 @@ export default [
     tags: [ "object", "sumeru" ],
     notes: "蒼漠の囿土に点在する、鐘のギミック",
     pinyins: [{ char: "铎", pron: "duo2" }],
+    zhuyins: [{ char: "鐸", pron: "ㄉㄨㄛˊ" }],
   },
   {
     en: "Bright Flame Altar",

--- a/dataset/dictionary/organizations.ts
+++ b/dataset/dictionary/organizations.ts
@@ -278,6 +278,7 @@ export default [
     tags: [ "inazuma", "organization" ],
     notes: "綺良々の所属する配達会社",
     pinyins: [{ char: "狛", pron: "bo2" }],
+    zhuyins: [{ char: "狛", pron: "ㄅㄛˊ" }],
   },
 
   {

--- a/dataset/dictionary/quests.ts
+++ b/dataset/dictionary/quests.ts
@@ -570,6 +570,7 @@ export default [
     pronunciationJa: "サイコロ、ねことカードのせんじょう",
     tags: [ "mondstadt", "quest-world" ],
     pinyins: [{ char: "骰", pron: "tou2" }],
+    zhuyins: [{ char: "骰", pron: "ㄊㄡˊ" }],
   },
   {
     en: "Come Try Genius Invokation TCG!",
@@ -622,6 +623,7 @@ export default [
     pronunciationJa: "かいじょうのかでん",
     tags: [ "liyue", "quest-world" ],
     pinyins: [{ char: "钿", pron: "dian4" }],
+    zhuyins: [{ char: "鈿", pron: "ㄉㄧㄢˋ" }],
   },
   {
     en: "A Lone Ship In Guyun",
@@ -764,6 +766,7 @@ export default [
       zhTW: [ "古云有螭" ],
     },
     pinyins: [{ char: "螭", pron: "chi1" }],
+    zhuyins: [{ char: "螭", pron: "ㄔ" }],
   },
   {
     en: "A Provisional Arrangement",
@@ -829,6 +832,7 @@ export default [
     pronunciationJa: "さかんだくにははいどにもどる",
     tags: [ "liyue", "quest-world" ],
     pinyins: [{ char: "囿", pron: "you4" }],
+    zhuyins: [{ char: "囿", pron: "ㄧㄡˋ" }],
   },
   {
     en: "A Little Game",
@@ -845,6 +849,7 @@ export default [
     pronunciationJa: "ろっかのふうけいが",
     tags: [ "liyue", "quest-world" ],
     pinyins: [{ char: "渌", pron: "lu4" }],
+    zhuyins: [{ char: "淥", pron: "ㄌㄨˋ" }],
   },
   {
     en: "Fishing For Jade",
@@ -980,6 +985,7 @@ export default [
     pronunciationJa: "かみざくらおおはらい",
     tags: [ "inazuma", "quest-world" ],
     pinyins: [{ char: "祓", pron: "fu2" }],
+    zhuyins: [{ char: "祓", pron: "ㄈㄨˊ" }],
   },
   {
     en: "Yougou Cleansing",
@@ -989,6 +995,7 @@ export default [
     pronunciationJa: "ようごうばらい",
     tags: [ "inazuma", "quest-world" ],
     pinyins: [{ char: "祓", pron: "fu2" }],
+    zhuyins: [{ char: "祓", pron: "ㄈㄨˊ" }],
   },
   {
     en: "Tatara Tales",
@@ -998,6 +1005,7 @@ export default [
     pronunciationJa: "たたらものがたり",
     tags: [ "inazuma", "quest-world" ],
     pinyins: [{ char: "鞴", pron: "bei4" }],
+    zhuyins: [{ char: "鞴", pron: "ㄅㄟˋ" }],
   },
   {
     en: "Orobashi's Legacy",
@@ -1232,6 +1240,7 @@ export default [
     zhTW: "「海祇之牙」",
     tags: [ "inazuma", "quest-world" ],
     pinyins: [{ char: "祇", pron: "qi2" }],
+    zhuyins: [{ char: "祇", pron: "ㄑㄧˊ" }],
   },
   {
     en: "\"Tail of Watatsumi\"",
@@ -1240,6 +1249,7 @@ export default [
     zhTW: "「海祇之尾」",
     tags: [ "inazuma", "quest-world" ],
     pinyins: [{ char: "祇", pron: "qi2" }],
+    zhuyins: [{ char: "祇", pron: "ㄑㄧˊ" }],
   },
   {
     en: "\"Heart of Watatsumi\"",
@@ -1248,6 +1258,7 @@ export default [
     zhTW: "「海祇之心」",
     tags: [ "inazuma", "quest-world" ],
     pinyins: [{ char: "祇", pron: "qi2" }],
+    zhuyins: [{ char: "祇", pron: "ㄑㄧˊ" }],
   },
   {
     en: "Divine Plant of the Depths",
@@ -1381,6 +1392,7 @@ export default [
     pronunciationJa: "やちまたひこのしれん",
     tags: [ "inazuma", "quest-world" ],
     pinyins: [{ char: "衢", pron: "qu2" }],
+    zhuyins: [{ char: "衢", pron: "ㄑㄩˊ" }],
   },
   {
     en: "Yachimatahime's Trial",
@@ -1390,6 +1402,7 @@ export default [
     pronunciationJa: "やちまたひめのしれん",
     tags: [ "inazuma", "quest-world" ],
     pinyins: [{ char: "衢", pron: "qu2" }],
+    zhuyins: [{ char: "衢", pron: "ㄑㄩˊ" }],
   },
   {
     en: "Kunado's Trial",
@@ -1502,7 +1515,8 @@ export default [
     zhCN: "日轮与菅名山",
     zhTW: "日輪與菅名山",
     tags: [ "inazuma", "quest-world" ],
-    pinyins: [{ char: "菅", pron: "jian2" }],
+    pinyins: [{ char: "菅", pron: "jian1" }],
+    zhuyins: [{ char: "菅", pron: "ㄐㄧㄢ" }],
   },
   {
     en: "The Saga of Mr. Forgetful",
@@ -1671,6 +1685,7 @@ export default [
     tags: [ "sumeru", "quest-world" ],
     notes: "森林書から連なる世界任務の1つ",
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Courage is in the Heart",
@@ -2678,7 +2693,8 @@ export default [
     pronunciationJa: "ながひしゃくのしょう",
     notes: "香菱の伝説任務",
     tags: [ "liyue", "quest-story" ],
-    pinyins: [{ char: "杓", pron: "shao2" }],
+    pinyins: [{ char: "杓", pron: "biāo" }],
+    zhuyins: [{ char: "杓", pron: "ㄅㄧㄠ" }],
   },
   {
     en: "Fabulae Textile Chapter",
@@ -2862,6 +2878,7 @@ export default [
     notes: "アルハイゼンの伝説任務",
     tags: [ "sumeru", "quest-story" ],
     pinyins: [{ char: "隼", pron: "sun3" }],
+    zhuyins: [{ char: "隼", pron: "ㄙㄨㄣˇ" }],
   },
   {
     en: "Mantichora Chapter",
@@ -3500,6 +3517,7 @@ export default [
     pronunciationJa: "ほこらよ、もういちどすがたをあらわしてください",
     tags: [ "inazuma", "quest-daily" ],
     pinyins: [{ char: "龛", pron: "kan1" }],
+    zhuyins: [{ char: "龕", pron: "ㄎㄢ" }],
   },
   {
     en: "Playing With Fire... Works",

--- a/dataset/dictionary/sereniteapot.ts
+++ b/dataset/dictionary/sereniteapot.ts
@@ -168,6 +168,7 @@ export default [
     pronunciationJa: "すぎざい",
     tags: [ "sereniteapot", "mondstadt" ],
     pinyins: [{ char: "杉", pron: "sha1" }],
+    zhuyins: [{ char: "杉", pron: "ㄕㄚ" }],
   },
   {
     en: "Fragrant Cedar Wood",
@@ -277,6 +278,7 @@ export default [
     zhTW: "檉木",
     tags: [ "sereniteapot", "sumeru" ],
     pinyins: [{ char: "柽", pron: "cheng1" }],
+    zhuyins: [{ char: "檉", pron: "ㄔㄥ" }],
   },
   {
     en: "Mountain Date Wood",
@@ -375,5 +377,6 @@ export default [
     zhTW: "千籟至音·颻揚",
     tags: [ "sereniteapot" ],
     pinyins: [{ char: "飖", pron: "yao2" }],
+    zhuyins: [{ char: "颻", pron: "ㄧㄠˊ" }],
   },
 ] as const satisfies SourceWord[];

--- a/dataset/dictionary/specialties.ts
+++ b/dataset/dictionary/specialties.ts
@@ -96,6 +96,7 @@ export default [
     pronunciationJa: "げいしょうばな",
     tags: [ "specialty", "liyue" ],
     pinyins: [{ char: "霓", pron: "ni2" }, { char: "裳", pron: "chang2" }],
+    zhuyins: [{ char: "霓", pron: "ㄋㄧˊ" }, { char: "裳", pron: "ㄔㄤˊ" }],
   },
   {
     en: "Violetgrass",
@@ -121,6 +122,7 @@ export default [
     pronunciationJa: "せきはく",
     tags: [ "specialty", "liyue" ],
     pinyins: [{ char: "珀", pron: "po4" }],
+    zhuyins: [{ char: "珀", pron: "ㄆㄛˋ" }],
   },
   {
     en: "Noctilucous Jade",
@@ -175,6 +177,7 @@ export default [
     zhTW: "血斛",
     tags: [ "specialty", "inazuma" ],
     pinyins: [{ char: "斛", pron: "hu2" }],
+    zhuyins: [{ char: "斛", pron: "ㄏㄨˊ" }],
   },
   {
     en: "Lycoris",
@@ -222,6 +225,7 @@ export default [
     zhTW: "幽燈蕈",
     tags: [ "specialty", "inazuma" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   // Sumeru
   {

--- a/dataset/dictionary/story.ts
+++ b/dataset/dictionary/story.ts
@@ -646,6 +646,7 @@ export default [
     tags: [ "sumeru" ],
     notes: "アランナラの言葉で「人」",
     pinyins: [{ char: "菈", pron: "la1" }],
+    zhuyins: [{ char: "菈", pron: "ㄌㄚ" }],
   },
   {
     en: "Festival Utsava",
@@ -678,6 +679,7 @@ export default [
     tags: [ "sumeru" ],
     notes: "アランナラの言葉で「森」",
     pinyins: [{ char: "桓", pron: "huan2" }],
+    zhuyins: [{ char: "桓", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Valuka",

--- a/dataset/dictionary/system.ts
+++ b/dataset/dictionary/system.ts
@@ -764,6 +764,7 @@ export default [
     zhTW: "元素骰",
     notes: "七聖召喚のカードで用いるサイコロ",
     pinyins: [{ char: "骰", pron: "tou2" }],
+    zhuyins: [{ char: "骰", pron: "ㄊㄡˊ" }],
   },
   {
     en: "roll",
@@ -772,6 +773,7 @@ export default [
     zhTW: "投擲（元素骰）",
     notes: "七聖召喚で元素サイコロを振ること",
     pinyins: [{ char: "骰", pron: "tou2" }],
+    zhuyins: [{ char: "骰", pron: "ㄊㄡˊ" }],
   },
   {
     en: "reroll",
@@ -780,6 +782,7 @@ export default [
     zhTW: "重投（元素骰）",
     notes: "七聖召喚で元素サイコロを振り直すこと",
     pinyins: [{ char: "骰", pron: "tou2" }],
+    zhuyins: [{ char: "骰", pron: "ㄊㄡˊ" }],
   },
   {
     en: "Lucky Coin",

--- a/dataset/dictionary/talent-materials.ts
+++ b/dataset/dictionary/talent-materials.ts
@@ -249,6 +249,7 @@ export default [
     pronunciationJa: "ちゅうげんのおしえ",
     tags: [ "talent-material", "sumeru" ],
     pinyins: [{ char: "诤", pron: "zheng4" }],
+    zhuyins: [{ char: "諍", pron: "ㄓㄥˋ" }],
   },
   {
     en: "Guide to Admonition",
@@ -258,6 +259,7 @@ export default [
     pronunciationJa: "ちゅうげんのみちびき",
     tags: [ "talent-material", "sumeru" ],
     pinyins: [{ char: "诤", pron: "zheng4" }],
+    zhuyins: [{ char: "諍", pron: "ㄓㄥˋ" }],
   },
   {
     en: "Philosophies of Admonition",
@@ -267,6 +269,7 @@ export default [
     pronunciationJa: "ちゅうげんのてつがく",
     tags: [ "talent-material", "sumeru" ],
     pinyins: [{ char: "诤", pron: "zheng4" }],
+    zhuyins: [{ char: "諍", pron: "ㄓㄥˋ" }],
   },
   {
     en: "Teachings of Ingenuity",

--- a/dataset/dictionary/weapon-materials.ts
+++ b/dataset/dictionary/weapon-materials.ts
@@ -28,6 +28,7 @@ export default [
     tags: [ "weapon-material", "mondstadt" ],
     notes: "★3武器突破素材",
     pinyins: [{ char: "垣", pron: "yuan2" }],
+    zhuyins: [{ char: "垣", pron: "ㄩㄢˊ" }],
   },
   {
     en: "Tile of Decarabian's Tower",
@@ -70,6 +71,7 @@ export default [
     tags: [ "weapon-material", "mondstadt" ],
     notes: "★2武器突破素材",
     pinyins: [{ char: "龀", pron: "he2" }],
+    zhuyins: [{ char: "齔", pron: "ㄏㄜˊ" }],
   },
   {
     en: "Dream of the Dandelion Gladiator",
@@ -507,6 +509,7 @@ export default [
     pronunciationJa: "じゅんせいなしずくのかんせん",
     tags: [ "weapon-material", "fontaine" ],
     pinyins: [{ char: "醴", pron: "li3" }],
+    zhuyins: [{ char: "醴", pron: "ㄌㄧˇ" }],
     notes: "★4武器突破素材",
   },
   {

--- a/dataset/dictionary/weapons.ts
+++ b/dataset/dictionary/weapons.ts
@@ -308,6 +308,7 @@ export default [
     pronunciationJa: "せんきょけん",
     tags: [ "weapon", "sword" ],
     pinyins: [{ char: "坞", pron: "wu4" }],
+    zhuyins: [{ char: "塢", pron: "ㄨˋ" }],
   },
   {
     en: "Sword of Narzissenkreuz",
@@ -368,6 +369,7 @@ export default [
     pronunciationJa: "ざんさんのやいば",
     tags: [ "weapon", "sword" ],
     pinyins: [{ char: "斫", pron: "zhuo2" }],
+    zhuyins: [{ char: "斫", pron: "ㄓㄨㄛˊ" }],
   },
   {
     en: "Primordial Jade Cutter",
@@ -673,6 +675,7 @@ export default [
     pronunciationJa: "マカイラのみずいろ",
     tags: [ "weapon", "claymore" ],
     pinyins: [{ char: "菈", pron: "la1" }],
+    zhuyins: [{ char: "菈", pron: "ㄌㄚ" }],
   },
   {
     en: "Mailed Flower",
@@ -860,6 +863,7 @@ export default [
     pronunciationJa: "ほこやり",
     tags: [ "weapon", "polearm" ],
     pinyins: [{ char: "钺", pron: "yue4" }],
+    zhuyins: [{ char: "鉞", pron: "ㄩㄝˋ" }],
   },
   {
     en: "Black Tassel",
@@ -979,6 +983,7 @@ export default [
     tags: [ "weapon" ],
     notes: "「漁獲」の精錬素材",
     pinyins: [{ char: "枡", pron: "sheng1" }],
+    zhuyins: [{ char: "枡", pron: "ㄕㄥ" }],
   },
   {
     en: "Wavebreaker's Fin",
@@ -1101,6 +1106,7 @@ export default [
       zhTW: [ "貫虹" ],
     },
     pinyins: [{ char: "槊", pron: "shuo4" }],
+    zhuyins: [{ char: "槊", pron: "ㄕㄨㄛˋ" }],
   },
   {
     en: "Staff of Homa",
@@ -1128,6 +1134,7 @@ export default [
       zhTW: [ "薙刀", "剃刀" ],
     },
     pinyins: [{ char: "薙", pron: "ti4" }],
+    zhuyins: [{ char: "薙", pron: "ㄊㄧˋ" }],
   },
   {
     en: "Calamity Queller",
@@ -1276,6 +1283,7 @@ export default [
     pronunciationJa: "ゆみぞう",
     tags: [ "weapon", "bow" ],
     pinyins: [{ char: "藏", pron: "cang2" }],
+    zhuyins: [{ char: "藏", pron: "ㄘㄤˊ" }],
   },
   {
     en: "Prototype Crescent",
@@ -1288,6 +1296,7 @@ export default [
       ja: [ "澹月" ],
     },
     pinyins: [{ char: "澹", pron: "dan4" }],
+    zhuyins: [{ char: "澹", pron: "ㄉㄢˋ" }],
   },
   {
     en: "Compound Bow",
@@ -1394,6 +1403,7 @@ export default [
     pronunciationJa: "トキのくちばし",
     tags: [ "weapon", "bow" ],
     pinyins: [{ char: "鹮", pron: "huan2" }],
+    zhuyins: [{ char: "䴉", pron: "ㄏㄨㄢˊ" }],
   },
   {
     en: "Congealed Pupa Wax",
@@ -1461,7 +1471,7 @@ export default [
     notesEn: "v5.6 Limited Time Event \"Whirling Waltz\" Reward",
     notes: "v5.6 期間限定イベント「ハーモニック・ワルツ」報酬",
     notesZh: "v5.6 限时活动「和旋舞剧」奖励",
-    
+
     tags: [ "weapon", "bow" ],
   },
   // ★5
@@ -1503,6 +1513,7 @@ export default [
       zhTW: [ "終末弓" ],
     },
     pinyins: [{ char: "嗟", pron: "jie1" }],
+    zhuyins: [{ char: "嗟", pron: "ㄐㄧㄝ" }],
   },
   {
     en: "Thundering Pulse",
@@ -1635,6 +1646,7 @@ export default [
     pronunciationJa: "とっきゅうのほうぎょく",
     tags: [ "weapon", "catalyst" ],
     pinyins: [{ char: "珏", pron: "jue2" }],
+    zhuyins: [{ char: "珏", pron: "ㄐㄩㄝˊ" }],
   },
   // ★4
   {
@@ -1687,6 +1699,7 @@ export default [
       ja: [ "金珀" ],
     },
     pinyins: [{ char: "珀", pron: "po4" }],
+    zhuyins: [{ char: "珀", pron: "ㄆㄛˋ" }],
   },
   {
     en: "Mappa Mare",
@@ -1909,6 +1922,7 @@ export default [
     // pronunciationJa: "へきらくのろう", // TODO Need Check
     tags: [ "weapon", "catalyst" ],
     pinyins: [{ char: "珑", pron: "long2" }],
+    zhuyins: [{ char: "瓏", pron: "ㄌㄨㄥˊ" }],
   },
   {
     en: "Tome of the Eternal Flow",

--- a/dataset/dictionary/y-events.ts
+++ b/dataset/dictionary/y-events.ts
@@ -2077,6 +2077,7 @@ export default [
     notes: "v3.8 期間限定イベント「涼夏! 楽園? 大秘境!」で修理する装置",
     tags: [ "event", "object" ],
     pinyins: [{ char: "縠", pron: "hu2" }],
+    zhuyins: [{ char: "縠", pron: "ㄏㄨˊ" }],
     variants: {
       zhCN: [ "核心轮毂" ],
       zhTW: [ "核心輪轂" ],
@@ -2294,6 +2295,7 @@ export default [
     zhCN: "伽吠毗陀",
     zhTW: "伽吠毗陀",
     pinyins: [{ char: "毗", pron: "pi2" }],
+    zhuyins: [{ char: "毗", pron: "ㄆㄧˊ" }],
     notes: "v3.7 期間限定イベント「決闘! 召喚の頂!」に登場する人物。七聖召喚の開発者の1人",
     tags: [ "event", "character-sub" ],
   },
@@ -2493,6 +2495,7 @@ export default [
     zhTW: "施芮婭",
     notes: "v3.6 期間限定イベント「轟々たる風砂」の登場人物",
     pinyins: [{ char: "芮", pron: "rui4" }],
+    zhuyins: [{ char: "芮", pron: "ㄖㄨㄟˋ" }],
     tags: [ "event", "character-sub" ],
   },
   {
@@ -2567,6 +2570,7 @@ export default [
     notes: "v3.5 期間限定イベント",
     tags: [ "event" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Lil' Fungus / Lil' Fungi",
@@ -2576,6 +2580,7 @@ export default [
     notes: "v3.5 期間限定イベント「チエキノコン布陣」で用いる、チエキノコンをモチーフにした駒。Lil' Fungus が単数形、Lil' Fungi が複数形。",
     tags: [ "event" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Marvelous Gel",
@@ -2673,6 +2678,7 @@ export default [
     notes: "v3.4 期間限定イベント「華舞う夜の旋律」(海灯祭) で、鍾離から取ってくるよう言われるタケノコ",
     tags: [ "event", "item" ],
     pinyins: [{ char: "蘖", pron: "nie4" }],
+    zhuyins: [{ char: "櫱", pron: "ㄋㄧㄝˋ" }],
   },
   {
     en: "The Exquisite Night Chimes",
@@ -2683,6 +2689,7 @@ export default [
     notes: "v3.4 期間限定イベント。海灯祭のイベント名",
     tags: [ "event" ],
     pinyins: [{ char: "磬", pron: "qing4" }],
+    zhuyins: [{ char: "磬", pron: "ㄑㄧㄥˋ" }],
   },
   {
     en: "Radiant Sparks",
@@ -2859,6 +2866,7 @@ export default [
     notes: "v3.2 期間限定イベント",
     tags: [ "event" ],
     pinyins: [{ char: "蕈", pron: "xun4" }],
+    zhuyins: [{ char: "蕈", pron: "ㄒㄩㄣˋ" }],
   },
   {
     en: "Nilotpala Cup Beast Tamers Tournament",
@@ -3412,6 +3420,7 @@ export default [
     notes: "v2.5 期間限定イベント",
     tags: [ "event" ],
     pinyins: [{ char: "飨", pron: "xiang3" }],
+    zhuyins: [{ char: "饗", pron: "ㄒㄧㄤˇ" }],
   },
   {
     en: "Bokuso Box",

--- a/dataset/dictionary/z-archives.ts
+++ b/dataset/dictionary/z-archives.ts
@@ -20,6 +20,7 @@ export default [
     notes: "聖遺物セット「悠久の磐岩」(Archaic Petra) の1つ",
     tags: [ "artifact-piece" ],
     pinyins: [{ char: "嵯", pron: "cuo2" }, { char: "峨", pron: "e2" }],
+    zhuyins: [{ char: "嵯", pron: "ㄘㄨㄛˊ" }, { char: "峨", pron: "ㄜˊ" }],
   },
   {
     en: "Sundial of Enduring Jade",
@@ -29,6 +30,7 @@ export default [
     notes: "聖遺物セット「悠久の磐岩」(Archaic Petra) の1つ",
     tags: [ "artifact-piece" ],
     pinyins: [{ char: "晷", pron: "gui3" }],
+    zhuyins: [{ char: "晷", pron: "ㄍㄨㄟˇ" }],
   },
   {
     en: "Goblet of Chiseled Crag",
@@ -38,6 +40,7 @@ export default [
     notes: "聖遺物セット「悠久の磐岩」(Archaic Petra) の1つ",
     tags: [ "artifact-piece" ],
     pinyins: [{ char: "巉", pron: "chan2" }],
+    zhuyins: [{ char: "巉", pron: "ㄔㄢˊ" }],
   },
   {
     en: "Mask of Solitude Basalt",
@@ -829,6 +832,7 @@ export default [
     notes: "聖遺物セット「千岩牢固」(Tenacity of the Millelith) の1つ",
     tags: [ "artifact-piece" ],
     pinyins: [{ char: "晷", pron: "gui3" }],
+    zhuyins: [{ char: "晷", pron: "ㄍㄨㄟˇ" }],
   },
   {
     en: "Noble's Pledging Vessel",
@@ -848,6 +852,7 @@ export default [
     notes: "聖遺物セット「千岩牢固」(Tenacity of the Millelith) の1つ",
     tags: [ "artifact-piece" ],
     pinyins: [{ char: "鍪", pron: "mou2" }],
+    zhuyins: [{ char: "鍪", pron: "ㄇㄡˊ" }],
   },
 
   {
@@ -1267,6 +1272,7 @@ export default [
     notes: "モシリの殻の挑戦名",
     tags: [ "inazuma" ],
     pinyins: [{ char: "砺", pron: "li4" }],
+    zhuyins: [{ char: "礪", pron: "ㄌㄧˋ" }],
   },
   {
     en: "Necropolis",

--- a/libs/types.ts
+++ b/libs/types.ts
@@ -23,12 +23,21 @@ export type Word = {
     /** The pronunciation for `pinyins.char` */
     pron: string;
   }[];
+  /** Zhuyin for rarely-used characters (生僻字) */
+  zhuyins?: {
+    /** A single rarely-used character (生僻字) included in `zhTW` */
+    char: string;
+    /** The pronunciation for `zhuyins.char` */
+    pron: string;
+  }[];
   /** Note in Japanese */
   notes?: string;
   /** Note in English */
   notesEn?: string;
   /** Note in Simplified Chinese */
   notesZh?: string;
+  /** Note in Traditional Chinese */
+  notesZhTW?: string;
   /** Tag IDs for this word */
   tags?: TagID[];
   /**

--- a/tests/dataset.test.ts
+++ b/tests/dataset.test.ts
@@ -73,6 +73,7 @@ test("if dictionary JSON does not have invalid keys", async () => { // eslint-di
         key === "zhTW" ||
         key === "pronunciationJa" ||
         key === "pinyins" ||
+        key === "zhuyins" ||
         key === "notes" ||
         key === "notesEn" ||
         key === "notesZh" ||
@@ -91,6 +92,17 @@ test("if dictionary JSON does not have invalid keys", async () => { // eslint-di
           ok(
             pinyinKey === "char" || pinyinKey === "pron",
             `"pinyins[].${pinyinKey}" is not a valid key.`
+          );
+        }
+      }
+    }
+
+    if (word.zhuyins) {
+      for (const zhuyin of word.zhuyins) {
+        for (const zhuyinKey of Object.keys(zhuyin)) {
+          ok(
+            zhuyinKey === "char" || zhuyinKey === "pron",
+            `"zhuyins[].${zhuyinKey}" is not a valid key.`
           );
         }
       }


### PR DESCRIPTION
This patch is only about adding zhuyin.

Related to https://github.com/xicri/genshin-langdata/issues/409.

Some corrections are made:
- 菅 should be jiān ㄐㄧㄢ
- 杓 should be biāo ㄅㄧㄠ