### PR TITLE
Add new keywords for Version 5.7 sequel genshin-langdataVersion5.7 sequel

### DIFF
--- a/dataset/dictionary/characters-general.ts
+++ b/dataset/dictionary/characters-general.ts
@@ -94,15 +94,16 @@ export default [
     tags: [ "character-sub" ],
   },
 
-  //
-  // Heavenly Principle
-  //
   {
-    en: "Sustainer of Heavenly Principles",
-    ja: "天理の調停者",
-    zhCN: "天理的维系者",
-    zhTW: "天理的維繫者",
+    en: "Sustainer of \"Heavenly Principles\"",
+    ja: "「天理」の調停者",
+    zhCN: "「天理」的维系者",
+    zhTW: "「天理」的維繫者",
     pronunciationJa: "てんりのちょうていしゃ",
+    notesEn: "Another name for \"Ruler of Space\"",
+    notes: "空の執政の別の呼び方",
+    notesZh: "空之执政的代称。",
+    notesZhTW: "空之執政的代稱。",
     tags: [ "character-sub" ],
   },
   {
@@ -192,6 +193,21 @@ export default [
     notes: "ナベリウスの称号",
     notesZh: "纳贝里士的称号。",
     notesZhTW: "納貝里士的稱號。",
+  },
+  {
+    en: "Asmoday", // TODO: maybe "Sustainer of Space"?
+    ja: "アスモダイ",
+    zhCN: "阿斯莫代",
+    zhTW: "阿斯莫代",
+    tags: [ "character-sub" ],
+  },
+  {
+    en: "Ruler of Space", // TODO: maybe "Asmoday"?
+    ja: "空の執政",
+    zhCN: "空之执政",
+    zhTW: "空之執政",
+    pronunciationJa: "くうのしっせい",
+    tags: [ "mondstadt", "title" ],
   },
   {
     en: "The Trinity of Moon Goddesses",

--- a/dataset/dictionary/characters-mondstadt.ts
+++ b/dataset/dictionary/characters-mondstadt.ts
@@ -485,7 +485,8 @@ export default [
     ja: "ドゥリン",
     zhCN: "杜林",
     zhTW: "杜林",
-    tags: [ "mondstadt", "dragonspine", "character-sub" ],
+    notes: "レインドットに創造された龍、もしくは、アルベドによっての人の姿に錬成された「ちびドゥリン」",
+    tags: [ "mondstadt", "nodkrai", "dragonspine", "character-sub" ],   //　TODO: Maybe a playable character, but not confirmed yet.
   },
   {
     en: "Andrius",

--- a/dataset/dictionary/characters-nodkrai.ts
+++ b/dataset/dictionary/characters-nodkrai.ts
@@ -9,7 +9,45 @@ export default [
     ja: "イネファ",
     zhCN: "伊涅芙",
     zhTW: "伊涅芙",
+    tags: [ "nodkrai", "character-main" ],
+  },
+  {
+    en: "Lauma",
+    ja: "ラウマ",
+    zhCN: "菈乌玛",
+    zhTW: "菈烏瑪",
     tags: [ "nodkrai", "character-main" ],    // TODO: Maybe a playable character from Nod-Krai, but not confirmed yet.
+  },
+  {
+    en: "Nefer",
+    ja: "ネフェル",
+    zhCN: "奈芙尔",
+    zhTW: "奈芙爾",
+    tags: [ "nodkrai", "character-main" ],    // TODO: Maybe a playable character from Nod-Krai, but not confirmed yet.
+  },
+  {
+    en: "Flins",
+    ja: "フリンズ",
+    zhCN: "菲林斯",
+    zhTW: "菲林斯",
+    tags: [ "nodkrai", "character-main" ],    // TODO: Maybe a playable character from Nod-Krai, but not confirmed yet.
+  },
+  {
+    en: "Kyryll Chudomirovich Flins",
+    ja: "キリル・チュードミロヴィッチ・フリンズ",
+    zhCN: "克里洛·楚德米洛维奇·菲林斯",
+    zhTW: "克里洛·楚德米洛維奇·菲林斯",
+    notesEn: "Full name of Flins",
+    notes: "フリンズのフルネーム",
+    tags: [ "nodkrai", "character-main" ],    // TODO: Maybe a playable character from Nod-Krai, but not confirmed yet.
+  },
+  {
+    en: "\"Moon Maiden\"",
+    ja: "「月の少女」",
+    zhCN: "「月之少女」",
+    zhTW: "「月之少女」",
+    pronunciationJa: "つきのしょうじょ",
+    tags: [ "nodkrai", "title" ],    // TODO: Maybe a playable character from Nod-Krai, but not confirmed yet.
   },
 
   //
@@ -25,5 +63,19 @@ export default [
     notesZhTW: "限時網頁活動「空月之歌」中的資訊。",
     pronunciationJa: "ゆきぐにのようせい",
     tags: [ "nodkrai", "character-sub" ],
+  },
+  {
+    en: "Aino",
+    ja: "アイノ",
+    zhCN: "爱诺",
+    zhTW: "愛諾",
+    tags: [ "nodkrai", "character-sub" ],    // TODO: Maybe a NPC character from Nod-Krai, but not confirmed yet.
+  },
+  {
+    en: "Jahoda",
+    ja: "ヤフォダ",
+    zhCN: "雅珂达",
+    zhTW: "雅珂達",
+    tags: [ "nodkrai", "character-sub" ],    // TODO: Maybe a NPC character from Nod-Krai, but not confirmed yet.
   },
 ] as const satisfies SourceWord[];

--- a/dataset/dictionary/facilities.ts
+++ b/dataset/dictionary/facilities.ts
@@ -576,6 +576,15 @@ export default [
     pronunciationJa: "カチャカチャ・クルムカケこうぼう",
     tags: [ "nodkrai", "facility" ],
   },
+  {
+    en: "Kuuvahki Experimental Design Bureau",
+    ja: "クーヴァキ実験設計局",
+    zhCN: "月矩力试验设计局",
+    zhTW: "月矩力試驗設計局",
+    notes: "「ナド・クライ」特設サイトの情報",
+    pronunciationJa: "クーヴァキじっけんせっけいきょく",
+    tags: [ "nodkrai", "facility" ],
+  },
 
   //
   // Snezhnaya

--- a/dataset/dictionary/foods.ts
+++ b/dataset/dictionary/foods.ts
@@ -1330,6 +1330,20 @@ export default [
     zhTW: "蘋果捲捲",
     tags: [ "food" ],
   },
+  {
+    en: "Nine-Fruit Nectar",
+    ja: "フルーツネクター",
+    zhCN: "九果甘露饮",
+    zhTW: "九果甘露飲",
+    tags: [ "food" ],
+  },
+  {
+    en: "Bubblemilk Pie",
+    ja: "つぶつぶミルクパイ",
+    zhCN: "鲜奶珠珠派",
+    zhTW: "鮮奶珠珠派",
+    tags: [ "food" ],
+  },
 
   // ★★★★
   {
@@ -1504,6 +1518,13 @@ export default [
     ja: "ミニドゥボールケーキ・改良版",
     zhCN: "德波小蛋糕·改良型",
     zhTW: "德波小蛋糕·改良型",
+    tags: [ "food" ],
+  },
+  {
+    en: "Meat-Lover's Feast",
+    ja: "ミートラバーフェスタ",
+    zhCN: "肉肉盛宴餐",
+    zhTW: "肉肉盛宴餐",
     tags: [ "food" ],
   },
 

--- a/dataset/dictionary/items.ts
+++ b/dataset/dictionary/items.ts
@@ -2438,4 +2438,20 @@ export default [
     pronunciationJa: "おおつごもりのかんせい",
     notes: "香菱のコスチューム",
   },
+  {
+    en: "Tranquil Banquet",
+    ja: "静謐の饗宴",
+    zhCN: "静暇雅宴",
+    zhTW: "靜暇雅宴",
+    pronunciationJa: "せいひつのきょうえん",
+    notes: "夜蘭のコスチューム",
+  },
+  {
+    en: "Adventures in Blazing Hue",
+    ja: "燃えろ! ラクガキ大冒険",
+    zhCN: "炽绘奇旅",
+    zhTW: "熾繪奇旅",
+    pronunciationJa: "もえろ! ラクガキだいぼうけん",
+    notes: "ベネットのコスチューム",
+  },
 ] as const satisfies SourceWord[];

--- a/dataset/dictionary/locations.ts
+++ b/dataset/dictionary/locations.ts
@@ -3156,12 +3156,56 @@ export default [
     tags: [ "nodkrai", "location" ],
   },
   {
+    en: "Paha Isle",
+    ja: "パハ島",
+    zhCN: "帕哈岛",
+    zhTW: "帕哈島",
+    pronunciationJa: "パハとう / パハじま",
+    tags: [ "nodkrai", "location" ],
+    notes: "「ナド・クライ」特設サイトの情報",
+  },
+  {
     en: "Hiisi Island",
     ja: "ヒーシ島",
     zhCN: "希汐岛",
     zhTW: "希汐島",
+    pronunciationJa: "ヒーシとう / ヒーシじま",
     tags: [ "nodkrai", "location" ],
     notes: "期間限定Webイベント「空月の歌」の情報",
+  },
+  {
+    en: "Blue Amber Lake",
+    ja: "青い琥珀",
+    zhCN: "蓝珀湖",
+    zhTW: "藍珀湖",   // TODO need check. 『「ナド・クライ」特設サイト』では「蓝珀湖」で記載されているが、「蓝」は繫体文字で一般的に使われているのか?
+    pronunciationJa: "あおいこはく",
+    tags: [ "nodkrai", "location" ],
+    notes: "「ナド・クライ」特設サイトの情報",
+  },
+  {
+    en: "Lempo Isle",
+    ja: "レンポ島",
+    zhCN: "伦波岛",
+    zhTW: "倫波島",
+    pronunciationJa: "レンポとう / レンポじま",
+    tags: [ "nodkrai", "location" ],
+    notes: "「ナド・クライ」特設サイトの情報",
+  },
+  {
+    en: "Nasha Town",
+    ja: "ナシャタウン",
+    zhCN: "那夏镇",
+    zhTW: "那夏鎮",
+    tags: [ "nodkrai", "location" ],
+    notes: "「ナド・クライ」特設サイトの情報",
+  },
+  {
+    en: "The presence of the Abyss grows...",  // TODO need check. may not be a location
+    ja: "蠢くアビスの気配…",
+    zhCN: "深渊的气息正在酝酿…",
+    zhTW: "深淵的氣息正在醞釀…",
+    tags: [ "nodkrai", "location" ],
+    notes: "「ナド・クライ」特設サイトの情報",
   },
 
   //

--- a/dataset/dictionary/y-events.ts
+++ b/dataset/dictionary/y-events.ts
@@ -232,6 +232,26 @@ export default [
 
   // v5.7
   {
+    en: "Fearsome Ferocious Firepower",
+    ja: "ハチャメチャ・カラフルバズーカ",
+    zhCN: "轰隆轰隆缤纷火力",
+    zhTW: "轟隆轟隆繽紛火力",
+    tags: [ "event", "fontaine" ],
+    notesEn: "Limited Time Event in v5.7",
+    notes: "v5.7 期間限定イベント",
+    notesZh: "v5.7 中的限时活动",
+  },
+  {
+    en: "Reminiscent Regimen: Frenzy",
+    ja: "追憶練行・死闘編",
+    zhCN: "追想练行·豪斗篇",
+    zhTW: "追想練行·豪鬥篇",
+    tags: [ "event" ],
+    notesEn: "Limited Time Event in v5.7",
+    notes: "v5.7 期間限定イベント",
+    notesZh: "v5.7 中的限时活动",
+  },
+  {
     en: "Stygian Onslaught",
     ja: "幽境の激戦",
     zhCN: "幽境危战",
@@ -1557,7 +1577,7 @@ export default [
     zhCN: "小杜林",
     zhTW: "小杜林",
     tags: [ "event", "sumeru", "character-sub" ],
-    notes: "v4.8 期間限定イベント「陽夏！悪龍？童話の王国！」に登場するキャラクター。レインドットが創造したドゥリンとは別個体",
+    notes: "v4.8 期間限定イベント「陽夏！悪龍？童話の王国！」、魔神任務第間章第四幕「背理」に登場するキャラクター。レインドットが創造したドゥリンと融合して人の姿としてドゥリンになった",
   },
   {
     en: "Fell Dragon's Picturebook",

--- a/tests/dataset.test.ts
+++ b/tests/dataset.test.ts
@@ -234,7 +234,7 @@ test("if property values of dictionary JSON complies the format.", async () => {
 });
 
 test("if the each translations do not include characters from the other languages", {
-  timeout: 45000
+  timeout: 20000
 }, async () => {
   type LangSpecificChars = {
     ja: string;
@@ -645,6 +645,56 @@ test("if the each translations do not include characters from the other language
       expect(word.zhTW).not.toMatch(/[ぁ-んァ-ヴー]/);
     }
 
+    /**
+     * This is a fix for the following problem:
+     * The test takes too long to determine Japanese/Chinese unique characters.
+     */
+    const wordsJA = []
+    const wordsCN = []
+    const wordsJAwoTW = []
+    const wordsCNwoTW = []
+    const wordsTWwoCN = []
+    const wordsTwwoJA = []
+    for (const char of langSpecificChars) {
+      if (char.ja) {
+        wordsJA.push(char.ja)
+        if (char["zh-TW"] && char["zh-TW"] !== char.ja) {
+          wordsTwwoJA.push(char["zh-TW"])
+        }
+      }
+
+      if (char["zh-CN"]) {
+        wordsCN.push(char["zh-CN"])
+        if (char["zh-TW"] && char["zh-TW"] !== char["zh-CN"]) {
+          wordsCNwoTW.push(char["zh-CN"])
+        }
+      }
+
+      if (char["zh-TW"]) {
+        if (char["zh-CN"] && char["zh-TW"] !== char["zh-CN"]) {
+          wordsTWwoCN.push(char["zh-TW"])
+        }
+        if (char.ja && char["zh-TW"] !== char.ja) {
+          wordsJAwoTW.push(char.ja)
+        }
+      }
+    }
+
+    if (word.ja) {
+      expect(word.ja).not.toContain(wordsCN.find(char => word.ja.includes(char)))
+      expect(word.ja).not.toContain(wordsTwwoJA.find(char => word.ja.includes(char)))
+    }
+
+    if (word.zhCN) {
+      expect(word.zhCN).not.toContain(wordsJA.find(char => word.zhCN.includes(char)))
+      expect(word.zhCN).not.toContain(wordsTWwoCN.find(char => word.zhCN.includes(char)))
+    }
+
+    if (word.zhTW) {
+      expect(word.zhTW).not.toContain(wordsCNwoTW.find(char => word.zhTW.includes(char)))
+      expect(word.zhTW).not.toContain(wordsJAwoTW.find(char => word.zhTW.includes(char)))
+    }
+    /**
     for (const char of langSpecificChars) {
       if (word.ja && word.zhCN) {
         if (char.ja !== char["zh-CN"]) {
@@ -667,6 +717,7 @@ test("if the each translations do not include characters from the other language
         }
       }
     }
+    */
   }
 });
 


### PR DESCRIPTION
Since we have advanced the story of the 2nd half of Ver 5.7, we will add keywords. This time, I am creating it from Genshin Impact's item, movie.

issue number: https://github.com/xicri/genshin-langdata/issues/427

Events
| English | Japanese | Simplified | Traditional | Note(en) | Note(ja) | Note(zh-cn) | memo|
|---|---|---|---|---|---|---|---|
| Fearsome Ferocious Firepower | ハチャメチャ・カラフルバズーカ | 轰隆轰隆缤纷火力 | 轟隆轟隆繽紛火力 |Limited Time Event in v5.7 | v5.7 期間限定イベント | v5.7 中的限时活动 | add tags:[events]
| Reminiscent Regimen: Frenzy | 追憶練行・死闘編 | 追想练行·豪斗篇 | 追想練行·豪鬥篇 |Limited Time Event in v5.7 | v5.7 期間限定イベント | v5.7 中的限时活动 | add tags:[events]

Food
| English | Japanese | Simplified | Traditional| Note(en) | Note(ja) | Note(zn-ch) | memo |
|---|---|---|---|---|---|---|---|
| Meat-Lover's Feast | ミートラバーフェスタ | 肉肉盛宴餐 | 肉肉盛宴餐 | | | | ★★★★
| Nine-Fruit Nectar | フルーツネクター | 九果甘露饮 | 九果甘露飲 | | | | ★★★
| Bubblemilk Pie | つぶつぶミルクパイ | 鲜奶珠珠派 | 鮮奶珠珠派 | | | | ★★★

Character (If there is no additional note, tags: [character-sub])
| English | Japanese | Simplified | Traditional | Note(en)  | Note(ja) | Note(zh-cn)  | memo |
|---|---|---|---|---|---|---|---|
| Sustainer of "Heavenly Principles" (**modified**) |  「天理」の調停者 | 「天理」的维系者 | 「天理」的維繫者 | Another name for "Ruler of Space" | 空の執政の別の呼び方 | 空之执政的代称。 |  空之執政的代稱。
| Asmoday | アスモダイ | 阿斯莫代 | 阿斯莫代 | | | | memo:『【原神】『テイワット』メインストーリー幕間PV-「神の限界」』より<br>Note: まだ「空の執政」とは明言されていない
| Ruler of Space | 空の執政(くうのしっせい) | 空之执政 | 空之執政 | | | | memo:『【原神】『テイワット』メインストーリー幕間PV-「神の限界」』より<br>Note: まだ「アスモダイ」とは明言されていない

<hr>

Character (If there is no additional note, tags: [nod-krai, character-sub])
| English | Japanese | Simplified | Traditional | Note(en)  | Note(ja) | Note(zh-cn)  | memo |
|---|---|---|---|---|---|---|---|
| Aino | アイノ | 爱诺 | 愛諾 | | | | memo: 『【原神】Ver.5.8公式PV「染夏！烈日？リゾート満喫！」』より
| Jahoda | ヤフォダ | 雅珂达 | 雅珂達 | | | | memo: 『【原神】空月の歌PV –「月夜の叙事詩」』より
| Ineffa | (入力済み)イネファ | 伊涅芙 | 伊涅芙 | | | | memo: 『【原神】空月の歌PV –「月夜の叙事詩」』より
| Durin | (入力済み)ドゥリン | 杜林 | 杜林| | レインドットに創造された龍、もしくは、ちびドゥリンの人の姿 | | memo: 『【原神】空月の歌PV –「月夜の叙事詩」』より
| Lauma | ラウマ | 菈乌玛 | 菈烏瑪 | | | | memo: 『【原神】ナド・クライプレビュー動画「静かなる霜夜へ」』より
| Nefer | ネフェル | 奈芙尔 | 奈芙爾 | | | | memo: 『【原神】空月の歌PV –「月夜の叙事詩」』より
| Flins | フリンズ | 菲林斯 | 菲林斯 | | | | memo: 『【原神】空月の歌PV –「月夜の叙事詩」』より
| Kyryll Chudomirovich Flins | キリル・チュードミロヴィッチ・フリンズ | 克里洛·楚德米洛维奇·菲林斯 | 克里洛·楚德米洛維奇·菲林斯 | | 「フリンズ」のフルネーム | | memo: 『【原神】空月の歌PV –「月夜の叙事詩」』より
| "Moon Maiden" | 「月の少女」 | 「月之少女」| 「月之少女」| | | | memo: 『【原神】空月の歌PV –「月夜の叙事詩」』より

Location(If there is no additional note, tags: [nod-krai])
| English | Japanese | Simplified | Traditional | Note(en)  | Note(ja) | Note(zh-cn)  | memo |
|---|---|---|---|---|---|---|---|
| Paha Isle | パハ島 | 帕哈岛 | 帕哈島 | | | | memo: 『「ナド・クライ」特設サイト』より
| Hiisi Island | ヒーシ島 | 希汐岛 | 希汐島 | | | | memo: 『「ナド・クライ」特設サイト』より
| Blue Amber Lake | 青い琥珀 | 蓝珀湖 | 蓝珀湖<br>memo: 画像を見ると「藍」ではなく「蓝」が使用されている。識者に聞く必要がある | | | | memo: 『「ナド・クライ」特設サイト』より
| Lempo Isle | レンポ島 | 伦波岛 | 倫波島 | | | | memo: 『「ナド・クライ」特設サイト』より
| Nasha Town | ナシャタウン | 那夏镇 | 那夏鎮 | | | | memo: 『「ナド・クライ」特設サイト』より
| The presence of the Abyss grows... | 蠢くアビスの気配… | 深渊的气息正在酝酿… | 深淵的氣息正在醞釀… | | | | memo: 『「ナド・クライ」特設サイト』より

Shop and Facility(If there is no additional note, tags: [nod-krai])
| English | Japanese | Simplified | Traditional | Note(en)  | Note(ja) | Note(zh-cn)  | memo |
|---|---|---|---|---|---|---|---|
| Kuuvahki Experimental Design Bureau | クーヴァキ実験設計局 | 月矩力试验设计局 | 月矩力試驗設計局 | | | | memo: 『「ナド・クライ」特設サイト』より

Item
| English | Japanese | Simplified | Traditional | Note(en)  | Note(ja) | Note(zh-cn)  | memo |
|---|---|---|---|---|---|---|---|
| Tranquil Banquet | 静謐の饗宴(せいひつのきょうえん) | 静暇雅宴 | 靜暇雅宴 | | 夜蘭のコスチューム | | memo: 『【原神】テイワットスタイル・コスチュームPV「鮮やかな夏色」』より
| Adventures in Blazing Hue | 燃えろ! ラクガキ大冒険(もえろ! ラクガキだいぼうけん) | 炽绘奇旅 | 熾繪奇旅 | | ベネットのコスチューム | | memo: 『【原神】テイワットスタイル・コスチュームPV「鮮やかな夏色」』より

**The test for detecting Japanese/Chinese unique characters was taking too long, so we have refactored it.**
tests/dataset.test.ts　L648-
```JavaScript
    /**
     * This is a fix for the following problem:
     * The test takes too long to determine Japanese/Chinese unique characters.
     */
    const wordsJA = []
    const wordsCN = []
    const wordsJAwoTW = []
    const wordsCNwoTW = []
    const wordsTWwoCN = []
    const wordsTwwoJA = []
    for (const char of langSpecificChars) {
      if (char.ja) {
        wordsJA.push(char.ja)
        if (char["zh-TW"] && char["zh-TW"] !== char.ja) {
          wordsTwwoJA.push(char["zh-TW"])
        }
      }

      if (char["zh-CN"]) {
        wordsCN.push(char["zh-CN"])
        if (char["zh-TW"] && char["zh-TW"] !== char["zh-CN"]) {
          wordsCNwoTW.push(char["zh-CN"])
        }
      }

      if (char["zh-TW"]) {
        if (char["zh-CN"] && char["zh-TW"] !== char["zh-CN"]) {
          wordsTWwoCN.push(char["zh-TW"])
        }
        if (char.ja && char["zh-TW"] !== char.ja) {
          wordsJAwoTW.push(char.ja)
        }
      }
    }

    if (word.ja) {
      expect(word.ja).not.toContain(wordsCN.find(char => word.ja.includes(char)))
      expect(word.ja).not.toContain(wordsTwwoJA.find(char => word.ja.includes(char)))
    }

    if (word.zhCN) {
      expect(word.zhCN).not.toContain(wordsJA.find(char => word.zhCN.includes(char)))
      expect(word.zhCN).not.toContain(wordsTWwoCN.find(char => word.zhCN.includes(char)))
    }

    if (word.zhTW) {
      expect(word.zhTW).not.toContain(wordsCNwoTW.find(char => word.zhTW.includes(char)))
      expect(word.zhTW).not.toContain(wordsJAwoTW.find(char => word.zhTW.includes(char)))
    }
```



