### PR TITLE
Speed ​​up spell checking for languages

### DIFF
--- a/tests/dataset.test.ts
+++ b/tests/dataset.test.ts
@@ -234,7 +234,7 @@ test("if property values of dictionary JSON complies the format.", async () => {
 });
 
 test("if the each translations do not include characters from the other languages", {
-  timeout: 90000
+  timeout: 20000
 }, async () => {
   type LangSpecificChars = {
     ja: string;
@@ -522,6 +522,11 @@ test("if the each translations do not include characters from the other language
       "zh-TW": "議",
     },
     {
+      ja: "語",
+      "zh-CN": "语",
+      "zh-TW": "語",
+    },
+    {
       ja: "謁",
       "zh-CN": "谒",
       "zh-TW": "謁",
@@ -636,6 +641,46 @@ test("if the each translations do not include characters from the other language
       "zh-CN": "卢",
       "zh-TW": "盧",
     },
+    {
+      ja: "達",
+      "zh-CN": "达",
+      "zh-TW": "達",
+    },
+    {
+      ja: "亜",
+      "zh-CN": "亚",
+      "zh-TW": "亞",
+    },
+    {
+      ja: "紀",
+      "zh-CN": "纪",
+      "zh-TW": "紀",
+    },
+    {
+      ja: "為",
+      "zh-CN": "为",
+      "zh-TW": "為",
+    },
+    {
+      ja: "動",
+      "zh-CN": "动",
+      "zh-TW": "動",
+    },
+    {
+      ja: "優",
+      "zh-CN": "优",
+      "zh-TW": "優",
+    },
+    {
+      ja: "門",
+      "zh-CN": "门",
+      "zh-TW": "門",
+    },
+    {
+      ja: "間",
+      "zh-CN": "间",
+      "zh-TW": "間",
+    },
   ];
 
   for (const word of words) {
@@ -647,27 +692,51 @@ test("if the each translations do not include characters from the other language
       expect(word.zhTW).not.toMatch(/[ぁ-んァ-ヴー]/);
     }
 
-    for (const char of langSpecificChars) {
-      if (word.ja && word.zhCN) {
-        if (char.ja !== char["zh-CN"]) {
-          expect(word.ja).not.toContain(char["zh-CN"]);
-          expect(word.zhCN).not.toContain(char.ja);
-        }
-      }
+    if (word.ja) {
+      const nonJapaneseChars = [
+        ...langSpecificChars
+          .filter((char) => char["zh-CN"] !== char.ja)
+          .map((char) => char["zh-CN"]),
+        ...langSpecificChars
+          .filter((char) => char["zh-TW"] !== char.ja)
+          .map((char) => char["zh-TW"])
+          .filter((charZhTw) => charZhTw !== undefined),
+      ];
 
-      if (word.ja && word.zhTW) {
-        if (char.ja !== char["zh-TW"]) {
-          expect(word.ja).not.toContain(char["zh-TW"]);
-          expect(word.zhTW).not.toContain(char.ja);
-        }
-      }
+      expect(word.ja).not.toContain(
+        nonJapaneseChars.find(char => word.ja.includes(char))
+      );
+    }
 
-      if (word.zhCN && word.zhTW) {
-        if (char["zh-CN"] !== char["zh-TW"]) {
-          expect(word.zhCN).not.toContain(char["zh-TW"]);
-          expect(word.zhTW).not.toContain(char["zh-CN"]);
-        }
-      }
+    if (word.zhCN) {
+      const nonSimplifiedChineseChars = [
+        ...langSpecificChars
+          .filter((char) => char["zh-CN"] !== char.ja)
+          .map((char) => char.ja),
+        ...langSpecificChars
+          .filter((char) => char["zh-TW"] !== char["zh-CN"])
+          .map((char) => char["zh-TW"])
+          .filter((charZhTw) => charZhTw !== undefined),
+      ];
+
+      expect(word.zhCN).not.toContain(
+        nonSimplifiedChineseChars.find(char => word.zhCN.includes(char))
+      );
+    }
+
+    if (word.zhTW) {
+      const nonTraditionalChineseChars = [
+        ...langSpecificChars
+          .filter((char) => char["zh-TW"] && char["zh-TW"] !== char["zh-CN"])
+          .map((char) => char["zh-CN"]),
+        ...langSpecificChars
+          .filter((char) => char["zh-TW"] !== char.ja)
+          .map((char) => char.ja),
+      ];
+
+      expect(word.zhTW).not.toContain(
+        nonTraditionalChineseChars.find(char => word.zhTW.includes(char))
+      );
     }
   }
 });


### PR DESCRIPTION
This is a resubmission of a previously withdrawn PR.(https://github.com/xicri/genshin-langdata/pull/430/commits/7b8d7bdd7c778cafabea2123d0ff2cb7090e36f3)

Simplify and improve the logic for preventing foreign language characters from being included in translations by using filtered arrays and removing nested loops.

1. Pre-build filtered check arrays for each language.
2. Remove the per-document spell-check loop.
