### PR TITLE
Create a tag for the Selenic Chronicles/月下見聞/月下纪闻/月下紀聞, in Nod-krai

### DIFF
--- a/dataset/dictionary/quests.ts
+++ b/dataset/dictionary/quests.ts
@@ -3169,6 +3169,123 @@ export default [
   },
 
   //
+  // Selenic Chronicles
+  //
+  {
+    en: "Selenic Chronicles",
+    ja: "月下見聞",
+    zhCN: "月下纪闻",
+    zhTW: "月下紀聞",
+    pronunciationJa: "げっかけんぶん",
+    tags: [ "natlan", "quest-selenic" ],
+  },
+  // Nod-Krai
+  {
+    en: "The Tale of the Gate Stone",
+    ja: "戸口にある石",
+    zhCN: "居于门户之石",
+    zhTW: "居於門戸之石",
+    pronunciationJa: "とぐちにあるいし",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "Gift of the Mirage",
+    ja: "蜃気楼の収穫",
+    zhCN: "蜃楼之获",
+    zhTW: "蜃樓之獲",
+    pronunciationJa: "しんきろうのしゅうかく",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "The Mirrors, the Maze, and the Tsar",
+    ja: "鏡と迷宮と国王",
+    zhCN: "镜子、迷宫与国王",
+    zhTW: "鏡子、迷宮與國王",
+    pronunciationJa: "かがみとめいきゅうとこくおう",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "For a Green Island...",
+    ja: "緑の島のために…",
+    zhCN: "为一座绿色的岛屿…",
+    zhTW: "為一座綠色的島嶼…",
+    pronunciationJa: "みどりのしまのために",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "Echoes of Unfinished Past",
+    ja: "これから始まる物語",
+    zhCN: "事犹未了",
+    zhTW: "事猶未了",
+    pronunciationJa: "これからはじまるものがたり",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "The Tale-Telling Heart",
+    ja: "密告の心",
+    zhCN: "告密的心",
+    zhTW: "告密的心",
+    pronunciationJa: "みっこくのこころ",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "Team Rigor, or Team Intuition?",
+    ja: "慎重派？ それとも直感派？",
+    zhCN: "是严谨派还是悟性派?",
+    zhTW: "是嚴謹派還是悟性派?",
+    pronunciationJa: "しんちょうは それともちょっかんは",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "Whisper Beneath the Waves",
+    ja: "波底のささやき",
+    zhCN: "浪底的低语",
+    zhTW: "浪底的低語",
+    pronunciationJa: "はていのささやき",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "The Power of Research",
+    ja: "研究の原動力",
+    zhCN: "科研的动力",
+    zhTW: "研究的動力",
+    pronunciationJa: "けんきゅうのげんどうりょく",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "Friends of Moleyvalley",
+    ja: "モレー谷の仲間たち",
+    zhCN: "莫雷谷的伙伴们",
+    zhTW: "莫雷谷的夥伴們",
+    pronunciationJa: "モレーたにのなかまたち",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "The Shoemaker's Children Go Barefoot",
+    ja: "靴職人の子はいつも裸足！",
+    zhCN: "鞋匠的孩子总是光脚",
+    zhTW: "鞋匠的孩子總是光脚",
+    pronunciationJa: "くつしょくにんのこはいつもはだし",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "Priorities First",
+    ja: "優先事項",
+    zhCN: "要事优先",
+    zhTW: "要事優先",
+    pronunciationJa: "ゆうせんじこう",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+  {
+    en: "Drifting Toward a Promised Sky",
+    ja: "空へ飛ぶ約束",
+    zhCN: "飞向天空的约定",
+    zhTW: "飛向天空的約定",
+    pronunciationJa: "そらへとぶやくそく",
+    tags: [ "nodkrai", "quest-selenic" ],
+  },
+
+  //
   // Commission Quests
   //
   {

--- a/dataset/tags.ts
+++ b/dataset/tags.ts
@@ -373,6 +373,18 @@ export const tags = {
       "zh-TW": "原神中的部族紀聞的英語和日語翻譯"
     }
   },
+  "quest-selenic": {
+    "en": "Selenic Chronicles",
+    "ja": "月下見聞",
+    "zh-CN": "月下纪闻",
+    "zh-TW": "月下紀聞	",
+    "title": {
+      "en": "Chinese & Japanese translations for the Selenic Chronicles in Genshin Impact",
+      "ja": "原神の月下見聞の英語・中国語表記一覧",
+      "zh-CN": "原神中的月下纪闻的英语和日语翻译",
+      "zh-TW": "原神中的月下見聞的英語和日語翻譯"
+    }
+  },
   "item": {
     "en": "Item",
     "ja": "アイテム",

--- a/tests/dataset.test.ts
+++ b/tests/dataset.test.ts
@@ -345,6 +345,7 @@ test("if the each translations do not include characters from the other language
     {
       ja: "緑",
       "zh-CN": "绿",
+      "zh-TW": "綠",
     },
     {
       ja: "約",
@@ -680,6 +681,16 @@ test("if the each translations do not include characters from the other language
       ja: "間",
       "zh-CN": "间",
       "zh-TW": "間",
+    },
+    {
+      ja: "厳",
+      "zh-CN": "严",
+      "zh-TW": "嚴",
+    },
+    {
+      ja: "飛",
+      "zh-CN": "飞",
+      "zh-TW": "飛",
     },
   ];
 


### PR DESCRIPTION
・ Introduced new Selenic Chronicles quests to the quests dataset and added the corresponding 'quest-selenic' tag with translations.
・ Create a tag for the Selenic Chronicles/月下見聞/月下纪闻/月下紀聞, in Nod-krai.

issue number: https://github.com/xicri/genshin-langdata/issues/447


Tags
| Key | English | Japanese | Simplified | Traditional | Note(en) | Note(ja) | Note(zh-cn) | memo|
|---|---|---|---|---|---|---|---|---|
| quest-selenic | Selenic Chronicles | 月下見聞 | 月下纪闻  | 月下紀聞 | Chinese & Japanese translations for the Selenic Chronicles in Genshin Impact | 原神の月下見聞の英語・中国語表記一覧 | 原神中的月下纪闻的英语和日语翻译

Selenic Chronicles
| English | Japanese | Simplified | Traditional | Note(en) | Note(ja) | Note(zh-cn) | memo|
|---|---|---|---|---|---|---|---|
| The Tale of the Gate Stone | 戸口にある石 | 居于门户之石 | 居於門戸之石
| Gift of the Mirage | 蜃気楼の収穫 | 蜃楼之获 | 蜃樓之獲
| The Mirrors, the Maze, and the Tsar | 鏡と迷宮と国王 | 镜子、迷宫与国王 | 鏡子、迷宮與國王
| For a Green Island... | 緑の島のために… | 为一座绿色的岛屿… | 為一座綠色的島嶼…
| Echoes of Unfinished Past | これから始まる物語 | 事犹未了 | 事猶未了
| The Tale-Telling Heart | 密告の心 | 告密的心 | 告密的心
| Team Rigor, of Tean Intuition? | 慎重派？ それとも直感派？ | 是严谨派还是悟性派? | 是[厳?]謹派還是悟性派?
| Whisper Beneath the Waves | 波底のささやき | 浪底的低语 | 浪底的低語
| The Power of Research | 研究の原動力 | 科研的动力 | 研究的動力
| Friends of Moleyvalley | モレー谷の仲間たち | 莫雷谷的伙伴们 | 莫雷谷的夥伴們
| The Shoemaker's Children Go Barefoot | 靴職人の子はいつも裸足！ | 鞋匠的孩子总是光脚 | 鞋匠的孩子總是光脚
| Priorities First | 優先事項 | 要事优先 | 要事優先
| Drifting Toward a Promised Sky | 空へ飛ぶ約束 | 飞向天空的约定 | 飛向天空的約定
